### PR TITLE
GRIFFIN-232 - add support pluggable predicates

### DIFF
--- a/griffin-doc/measure/predicates.md
+++ b/griffin-doc/measure/predicates.md
@@ -1,0 +1,77 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+#About predicates
+
+##Overview
+Sometimes we need to check certain conditions before starting a measurement. Depending on these conditions, start or not start the measurement. For example, check whether the file. For these purposes, serve as predicate functional.
+
+##Configure predicates
+
+For configuring predicates need add property to measure json:
+```
+{
+    ...
+     "data.sources": [
+        ...
+         "connectors": [
+                   "predicates": [
+                       {
+                         "type": "file.exist",
+                         "config": {
+                           "root.path": "/path/to/",
+                           "path": "file.ext,file2.txt"
+                         }
+                       }
+                   ],
+         ...
+         
+     ]
+}
+```
+
+Possible values for predicates.type:
+- "file.exist" - in this case creates predicate with class org.apache.griffin.core.job.FileExistPredicator. This predicate checks existence of files before starting Spark jobs.
+ ```
+                     {
+                         "type": "file.exist",
+                         "config": {
+                           "root.path": "/path/to/",
+                           "path": "file.ext,file2.txt"
+                         }
+                     }
+```
+
+- "custom" - in this case required transmit class name in the property "class" in config. 
+This example creates same predicate like in previous example
+```
+                     {
+                         "type": "custom",
+                         "config": {
+                           "class": "org.apache.griffin.core.job.FileExistPredicator",
+                           "root.path": "/path/to/",
+                           "path": "file.ext,file2.txt"
+                         }
+                     }
+```
+It important to notice that predicate class must satisfy follow conditions:
+- implement interface **org.apache.griffin.core.job.Predicator**
+- have constructor with argument of type **org.apache.griffin.core.job.entity.SegmentPredicate**
+
+

--- a/griffin-doc/measure/predicates.md
+++ b/griffin-doc/measure/predicates.md
@@ -92,5 +92,5 @@ First jar is executable Spring-Boot application, second jar you can use as a dep
 - Build the module into a jar file and put it in any folder (for example /path-to-jar)
 - Start the Griffin service application using command 
 ```
-java -Dloader.path=/path-to-jar/ -jar target/service-VERSION-exec.jar 
+java -cp target/service-VERSION-exec.jar -Dloader.path=/path-to-jar/ org.springframework.boot.loader.PropertiesLauncher
 ```

--- a/griffin-doc/measure/predicates.md
+++ b/griffin-doc/measure/predicates.md
@@ -78,18 +78,16 @@ It important to notice that predicate class must satisfy follow conditions:
 ##Deployment custom predicates
 For the creating custom predicate you need 
 1. Build the Griffin service using command
-```
-mvn clean install -Dspring-boot-maven-plugin.classifier=exec
-```
 As a result, two artifacts will be built  
-- **service-VERSION-exec.jar** - executable Spring-Boot application
-- **service-VERSION.jar** - jar, which we can use as a dependency
+- **service-VERSION.jar** - executable Spring-Boot application
+- **service-VERSION-lib.jar** - jar, which we can use as a dependency
 This step is necessary because we can't use executable Spring-Boot application as a dependency in our plugin. 
 2. Create module and add dependency that was built in previous step
 ```
          <dependency>
              <groupId>org.apache.griffin</groupId>
              <artifactId>service</artifactId>
+             <classifier>lib</classifier>
              <version>${griffin.version}</version>
              <scope>provided</scope>
          </dependency>
@@ -98,5 +96,5 @@ This step is necessary because we can't use executable Spring-Boot application a
 4. Build the module into a jar file and put it in any folder (for example /path-to-jar)
 5. Start the Griffin service application using command 
 ```
-java -cp target/service-VERSION-exec.jar -Dloader.path=/path-to-jar/ org.springframework.boot.loader.PropertiesLauncher
+java -cp target/service-VERSION.jar -Dloader.path=/path-to-jar/ org.springframework.boot.loader.PropertiesLauncher
 ```

--- a/griffin-doc/measure/predicates.md
+++ b/griffin-doc/measure/predicates.md
@@ -20,7 +20,8 @@ under the License.
 #About predicates
 
 ##Overview
-Sometimes we need to check certain conditions before starting a measurement. Depending on these conditions, start or not start the measurement. For example, check whether the file. For these purposes, serve as predicate functional.
+The purpose of predicates is obligate Griffin to check certain conditions before starting SparkSubmitJob. 
+Depending on these conditions Griffin need to start or not start the measurement.
 
 ##Configure predicates
 
@@ -55,7 +56,7 @@ Possible values for predicates.type:
                            "root.path": "/path/to/",
                            "path": "file.ext,file2.txt"
                          }
-                     }
+                       }
 ```
 
 - "custom" - in this case required transmit class name in the property "class" in config. 
@@ -68,10 +69,28 @@ This example creates same predicate like in previous example
                            "root.path": "/path/to/",
                            "path": "file.ext,file2.txt"
                          }
-                     }
+                       }
 ```
 It important to notice that predicate class must satisfy follow conditions:
 - implement interface **org.apache.griffin.core.job.Predicator**
 - have constructor with argument of type **org.apache.griffin.core.job.entity.SegmentPredicate**
 
-
+##Deployment custom predicates
+For the creating custom predicate you need 
+- Build the Griffin service to get two artifacts - **service-VERSION-exec.jar** and **service-VERSION.jar**. 
+First jar is executable Spring-Boot application, second jar you can use as a dependency in your custom predicate 
+- Create module and add dependency which was building in previous step
+```
+         <dependency>
+             <groupId>org.apache.griffin</groupId>
+             <artifactId>service</artifactId>
+             <version>${griffin.version}</version>
+             <scope>provided</scope>
+         </dependency>
+```
+- Create a Predicate class, which should, as mentioned earlier, implement the Predicator interface and have a constructor with an argument of type SegmentPredicate
+- Build the module into a jar file and put it in any folder (for example /path-to-jar)
+- Start the Griffin service application using command 
+```
+java -Dloader.path=/path-to-jar/ -jar target/service-VERSION-exec.jar 
+```

--- a/griffin-doc/measure/predicates.md
+++ b/griffin-doc/measure/predicates.md
@@ -77,9 +77,15 @@ It important to notice that predicate class must satisfy follow conditions:
 
 ##Deployment custom predicates
 For the creating custom predicate you need 
-- Build the Griffin service to get two artifacts - **service-VERSION-exec.jar** and **service-VERSION.jar**. 
-First jar is executable Spring-Boot application, second jar you can use as a dependency in your custom predicate 
-- Create module and add dependency which was building in previous step
+1. Build the Griffin service using command
+```
+mvn clean install -Dspring-boot-maven-plugin.classifier=exec
+```
+As a result, two artifacts will be built  
+- **service-VERSION-exec.jar** - executable Spring-Boot application
+- **service-VERSION.jar** - jar, which we can use as a dependency
+This step is necessary because we can't use executable Spring-Boot application as a dependency in our plugin. 
+2. Create module and add dependency that was built in previous step
 ```
          <dependency>
              <groupId>org.apache.griffin</groupId>
@@ -88,9 +94,9 @@ First jar is executable Spring-Boot application, second jar you can use as a dep
              <scope>provided</scope>
          </dependency>
 ```
-- Create a Predicate class, which should, as mentioned earlier, implement the Predicator interface and have a constructor with an argument of type SegmentPredicate
-- Build the module into a jar file and put it in any folder (for example /path-to-jar)
-- Start the Griffin service application using command 
+3. Create a Predicate class, which should, as mentioned earlier, implement the Predicator interface and have a constructor with an argument of type SegmentPredicate
+4. Build the module into a jar file and put it in any folder (for example /path-to-jar)
+5. Start the Griffin service application using command 
 ```
 java -cp target/service-VERSION-exec.jar -Dloader.path=/path-to-jar/ org.springframework.boot.loader.PropertiesLauncher
 ```

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -291,6 +291,7 @@ under the License.
                     </execution>
                 </executions>
                 <configuration>
+                    <classifier>exec</classifier>
                     <fork>true</fork>
                     <layout>JAR</layout>
                     <mainClass>org.apache.griffin.core.GriffinWebApplication</mainClass>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -44,7 +44,6 @@ under the License.
         <powermock.version>1.6.6</powermock.version>
         <mockito.version>1.10.19</mockito.version>
         <spring-boot-maven-plugin.version>1.5.1.RELEASE</spring-boot-maven-plugin.version>
-        <spring-boot-maven-plugin.classifier></spring-boot-maven-plugin.classifier>
         <derby.version>10.14.1.0</derby.version>
         <eclipselink.version>2.6.0</eclipselink.version>
         <mysql.java.version>5.1.47</mysql.java.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -281,6 +281,23 @@ under the License.
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedClassifierName>lib</shadedClassifierName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-maven-plugin.version}</version>
@@ -292,7 +309,6 @@ under the License.
                     </execution>
                 </executions>
                 <configuration>
-                    <classifier>${spring-boot-maven-plugin.classifier}</classifier>
                     <fork>true</fork>
                     <layout>JAR</layout>
                     <mainClass>org.apache.griffin.core.GriffinWebApplication</mainClass>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -293,7 +293,7 @@ under the License.
                 <configuration>
                     <classifier>exec</classifier>
                     <fork>true</fork>
-                    <layout>JAR</layout>
+                    <layout>ZIP</layout>
                     <mainClass>org.apache.griffin.core.GriffinWebApplication</mainClass>
                 </configuration>
             </plugin>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -281,17 +281,16 @@ under the License.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <shadedClassifierName>lib</shadedClassifierName>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <classifier>lib</classifier>
                         </configuration>
                     </execution>
                 </executions>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -293,7 +293,7 @@ under the License.
                 <configuration>
                     <classifier>exec</classifier>
                     <fork>true</fork>
-                    <layout>ZIP</layout>
+                    <layout>JAR</layout>
                     <mainClass>org.apache.griffin.core.GriffinWebApplication</mainClass>
                 </configuration>
             </plugin>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -44,6 +44,7 @@ under the License.
         <powermock.version>1.6.6</powermock.version>
         <mockito.version>1.10.19</mockito.version>
         <spring-boot-maven-plugin.version>1.5.1.RELEASE</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.classifier></spring-boot-maven-plugin.classifier>
         <derby.version>10.14.1.0</derby.version>
         <eclipselink.version>2.6.0</eclipselink.version>
         <mysql.java.version>5.1.47</mysql.java.version>
@@ -291,7 +292,7 @@ under the License.
                     </execution>
                 </executions>
                 <configuration>
-                    <classifier>exec</classifier>
+                    <classifier>${spring-boot-maven-plugin.classifier}</classifier>
                     <fork>true</fork>
                     <layout>JAR</layout>
                     <mainClass>org.apache.griffin.core.GriffinWebApplication</mainClass>
@@ -305,7 +306,6 @@ under the License.
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
-
             </plugin>
         </plugins>
     </build>

--- a/service/src/main/java/org/apache/griffin/core/exception/GriffinExceptionMessage.java
+++ b/service/src/main/java/org/apache/griffin/core/exception/GriffinExceptionMessage.java
@@ -54,6 +54,8 @@ public enum GriffinExceptionMessage {
 
     JOB_IS_IN_PAUSED_STATUS(40015, "The job is already in paused status."),
 
+    INVALID_MEASURE_PREDICATE(40016, "The measure predicate is invalid"),
+
     //404, "Not Found"
     MEASURE_ID_DOES_NOT_EXIST(40401, "Measure id does not exist"),
 
@@ -69,6 +71,8 @@ public enum GriffinExceptionMessage {
             "does not exist"),
 
     HDFS_FILE_NOT_EXIST(40407, "Hadoop data file not exist"),
+
+    PREDICATE_TYPE_NOT_FOUND(40408, "Unknown predicate type"),
 
     //409, "Conflict"
     MEASURE_NAME_ALREADY_EXIST(40901, "Measure name already exists"),

--- a/service/src/main/java/org/apache/griffin/core/job/SparkSubmitJob.java
+++ b/service/src/main/java/org/apache/griffin/core/job/SparkSubmitJob.java
@@ -185,17 +185,13 @@ public class SparkSubmitJob implements Job {
         if (StringUtils.isEmpty(json)) {
             return;
         }
-        List<Map<String, Object>> maps = toEntity(json,
-                new TypeReference<List<Map>>() {
+        List<SegmentPredicate> predicates = toEntity(json,
+                new TypeReference<List<SegmentPredicate>>() {
                 });
-        for (Map<String, Object> map : maps) {
-            SegmentPredicate sp = new SegmentPredicate();
-            sp.setType((String) map.get("type"));
-            sp.setConfigMap((Map<String, Object>) map.get("config"));
-            mPredicates.add(sp);
+        if (predicates != null) {
+            mPredicates.addAll(predicates);
         }
     }
-
     private String escapeCharacter(String str, String regex) {
         if (StringUtils.isEmpty(str)) {
             return str;

--- a/service/src/main/java/org/apache/griffin/core/job/factory/PredicatorFactory.java
+++ b/service/src/main/java/org/apache/griffin/core/job/factory/PredicatorFactory.java
@@ -19,25 +19,57 @@ under the License.
 
 package org.apache.griffin.core.job.factory;
 
+import org.apache.griffin.core.exception.GriffinException;
 import org.apache.griffin.core.job.FileExistPredicator;
 import org.apache.griffin.core.job.Predicator;
 import org.apache.griffin.core.job.entity.SegmentPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.PREDICATE_TYPE_NOT_FOUND;
+
 public class PredicatorFactory {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(PredicatorFactory.class);
 
     public static Predicator newPredicateInstance(SegmentPredicate segPredicate) {
-        Predicator predicate = null;
+        Predicator predicate;
         switch (segPredicate.getType()) {
             case "file.exist":
                 predicate = new FileExistPredicator(segPredicate);
                 break;
-            default:
-                LOGGER.warn("There is no predicate type that you input.");
+            case "custom":
+                predicate = getPredicateBean(segPredicate);
                 break;
+            default:
+                throw new GriffinException.NotFoundException(PREDICATE_TYPE_NOT_FOUND);
+        }
+        return predicate;
+    }
+
+    private static Predicator getPredicateBean(SegmentPredicate segmentPredicate) {
+        Predicator predicate;
+        String predicateClassName = (String) segmentPredicate.getConfigMap().get("class");
+        try {
+            Class clazz = Class.forName(predicateClassName);
+            Constructor<Predicator> constructor = clazz.getConstructor(SegmentPredicate.class);
+            predicate = constructor.newInstance(segmentPredicate);
+        } catch (ClassNotFoundException e) {
+            String message = "There is no predicate type that you input.";
+            LOGGER.error(message, e);
+            throw new GriffinException.ServiceException(message, e);
+        } catch (NoSuchMethodException e) {
+            String message = "For predicate with type " + predicateClassName +
+                    " constructor with parameter of type " + SegmentPredicate.class.getName() + " not found";
+            LOGGER.error(message, e);
+            throw new GriffinException.ServiceException(message, e);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            String message = "Error creating predicate bean";
+            LOGGER.error(message, e);
+            throw new GriffinException.ServiceException(message, e);
         }
         return predicate;
     }

--- a/service/src/main/java/org/apache/griffin/core/util/MeasureUtil.java
+++ b/service/src/main/java/org/apache/griffin/core/util/MeasureUtil.java
@@ -20,6 +20,7 @@ under the License.
 package org.apache.griffin.core.util;
 
 import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_CONNECTOR_NAME;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_MEASURE_PREDICATE;
 import static org.apache.griffin.core.exception.GriffinExceptionMessage.MISSING_METRIC_NAME;
 
 import java.util.ArrayList;
@@ -29,10 +30,10 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.measure.entity.DataSource;
-import org.apache.griffin.core.measure.entity.ExternalMeasure;
-import org.apache.griffin.core.measure.entity.GriffinMeasure;
-import org.apache.griffin.core.measure.entity.Measure;
+import org.apache.griffin.core.job.Predicator;
+import org.apache.griffin.core.job.entity.SegmentPredicate;
+import org.apache.griffin.core.job.factory.PredicatorFactory;
+import org.apache.griffin.core.measure.entity.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,27 @@ public class MeasureUtil {
             throw new GriffinException.BadRequestException
                     (INVALID_CONNECTOR_NAME);
         }
+        if (!validatePredicates(measure)) {
+            throw new GriffinException.BadRequestException(INVALID_MEASURE_PREDICATE);
+        }
+    }
+
+    private static boolean validatePredicates(GriffinMeasure measure) {
+        for (DataSource dataSource : measure.getDataSources()) {
+            for (DataConnector dataConnector: dataSource.getConnectors()) {
+                for (SegmentPredicate segmentPredicate : dataConnector.getPredicates()) {
+                    try {
+                        Predicator predicator = PredicatorFactory.newPredicateInstance(segmentPredicate);
+                        if (predicator == null) {
+                            return false;
+                        }
+                    } catch (Exception e) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     private static void validateExternalMeasure(ExternalMeasure measure) {

--- a/service/src/main/java/org/apache/griffin/core/util/MeasureUtil.java
+++ b/service/src/main/java/org/apache/griffin/core/util/MeasureUtil.java
@@ -65,10 +65,7 @@ public class MeasureUtil {
             for (DataConnector dataConnector: dataSource.getConnectors()) {
                 for (SegmentPredicate segmentPredicate : dataConnector.getPredicates()) {
                     try {
-                        Predicator predicator = PredicatorFactory.newPredicateInstance(segmentPredicate);
-                        if (predicator == null) {
-                            return false;
-                        }
+                        PredicatorFactory.newPredicateInstance(segmentPredicate);
                     } catch (Exception e) {
                         return false;
                     }

--- a/service/src/test/java/org/apache/griffin/core/job/SparkSubmitJobTest.java
+++ b/service/src/test/java/org/apache/griffin/core/job/SparkSubmitJobTest.java
@@ -19,19 +19,17 @@ under the License.
 
 package org.apache.griffin.core.job;
 
-import static org.apache.griffin.core.util.EntityMocksHelper.createFileExistPredicate;
-import static org.apache.griffin.core.util.EntityMocksHelper.createGriffinMeasure;
-import static org.apache.griffin.core.util.EntityMocksHelper.createJobDetail;
-import static org.apache.griffin.core.util.EntityMocksHelper.createJobInstance;
-import static org.apache.griffin.core.util.EntityMocksHelper.createSimpleTrigger;
+import static org.apache.griffin.core.util.EntityMocksHelper.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
 
+import org.apache.griffin.core.config.PropertiesConfig;
 import org.apache.griffin.core.job.entity.JobInstanceBean;
 import org.apache.griffin.core.job.entity.SegmentPredicate;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
@@ -70,7 +68,10 @@ public class SparkSubmitJobTest {
             return PropertiesUtil.getProperties(path,
                     new ClassPathResource(path));
         }
-
+        @Bean
+        public PropertiesConfig sparkConf() {
+            return new PropertiesConfig("src/test/resources", null);
+        }
     }
 
     @Autowired
@@ -183,6 +184,27 @@ public class SparkSubmitJobTest {
         JobExecutionContext context = mock(JobExecutionContext.class);
 
         sparkSubmitJob.execute(context);
+    }
+
+    @Test
+    public void testMultiplePredicatesWhichReturnsTrue() throws Exception {
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        JobInstanceBean instance = createJobInstance();
+        GriffinMeasure measure = createGriffinMeasure("measureName");
+        SegmentPredicate predicate = createMockPredicate();
+        SegmentPredicate secondPredicate = createMockPredicate();
+        JobDetail jd = createJobDetail(JsonUtil.toJson(measure), JsonUtil.toJson
+                (Arrays.asList(predicate, secondPredicate)));
+        given(context.getJobDetail()).willReturn(jd);
+        given(context.getTrigger()).willReturn(createSimpleTrigger(4, 5));
+        given(jobInstanceRepo.findByPredicateName(Matchers.anyString()))
+                .willReturn(instance);
+        sparkSubmitJob.execute(context);
+
+        verify(context, times(1)).getJobDetail();
+        verify(jobInstanceRepo, times(1)).findByPredicateName(
+                Matchers.anyString());
+        verify(jobInstanceRepo, times(1)).save(instance);
     }
 
 }

--- a/service/src/test/java/org/apache/griffin/core/job/factory/PredicatorFactoryTest.java
+++ b/service/src/test/java/org/apache/griffin/core/job/factory/PredicatorFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import static org.apache.griffin.core.util.EntityMocksHelper.createFileExistPredicate;
@@ -20,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 public class PredicatorFactoryTest {
 
     @Test
-    public void testFileExistPredicatorCreation() throws JsonProcessingException {
+    public void testFileExistPredicatorCreation() throws IOException {
         Predicator predicator = PredicatorFactory.newPredicateInstance(createFileExistPredicate());
         assertNotNull(predicator);
         assertTrue(predicator instanceof FileExistPredicator);

--- a/service/src/test/java/org/apache/griffin/core/job/factory/PredicatorFactoryTest.java
+++ b/service/src/test/java/org/apache/griffin/core/job/factory/PredicatorFactoryTest.java
@@ -1,0 +1,46 @@
+package org.apache.griffin.core.job.factory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.griffin.core.exception.GriffinException;
+import org.apache.griffin.core.job.FileExistPredicator;
+import org.apache.griffin.core.job.Predicator;
+import org.apache.griffin.core.job.entity.SegmentPredicate;
+import org.apache.griffin.core.util.PredicatorMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashMap;
+
+import static org.apache.griffin.core.util.EntityMocksHelper.createFileExistPredicate;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+public class PredicatorFactoryTest {
+
+    @Test
+    public void testFileExistPredicatorCreation() throws JsonProcessingException {
+        Predicator predicator = PredicatorFactory.newPredicateInstance(createFileExistPredicate());
+        assertNotNull(predicator);
+        assertTrue(predicator instanceof FileExistPredicator);
+    }
+
+    @Test(expected = GriffinException.NotFoundException.class)
+    public void testUnknownPredicator() throws JsonProcessingException {
+        PredicatorFactory.newPredicateInstance(
+                new SegmentPredicate("unknown", null));
+    }
+
+    @Test
+    public void testPluggablePredicator() throws JsonProcessingException {
+        String predicatorClass = "org.apache.griffin.core.util.PredicatorMock";
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("class", predicatorClass);
+        SegmentPredicate segmentPredicate = new SegmentPredicate("custom", null);
+        segmentPredicate.setConfigMap(map);
+        Predicator predicator = PredicatorFactory.newPredicateInstance(segmentPredicate);
+        assertNotNull(predicator);
+        assertTrue(predicator instanceof PredicatorMock);
+    }
+}

--- a/service/src/test/java/org/apache/griffin/core/util/EntityMocksHelper.java
+++ b/service/src/test/java/org/apache/griffin/core/util/EntityMocksHelper.java
@@ -217,6 +217,7 @@ public class EntityMocksHelper {
         jobDataMap.put(MEASURE_KEY, measureJson);
         jobDataMap.put(PREDICATES_KEY, predicatesJson);
         jobDataMap.put(JOB_NAME, "jobName");
+        jobDataMap.put("jobName", "jobName");
         jobDataMap.put(PREDICATE_JOB_NAME, "predicateJobName");
         jobDataMap.put(GRIFFIN_JOB_ID, 1L);
         jobDetail.setJobDataMap(jobDataMap);
@@ -224,11 +225,24 @@ public class EntityMocksHelper {
     }
 
     public static SegmentPredicate createFileExistPredicate()
-        throws JsonProcessingException {
+            throws IOException {
         Map<String, String> config = new HashMap<>();
         config.put("root.path", "hdfs:///griffin/demo_src");
         config.put("path", "/dt=#YYYYMMdd#/hour=#HH#/_DONE");
-        return new SegmentPredicate("file.exist", config);
+        SegmentPredicate segmentPredicate = new SegmentPredicate("file.exist", config);
+        segmentPredicate.setId(1L);
+        segmentPredicate.load();
+        return segmentPredicate;
+    }
+
+    public static SegmentPredicate createMockPredicate()
+            throws IOException {
+        Map<String, String> config = new HashMap<>();
+        config.put("class", "org.apache.griffin.core.util.PredicatorMock");
+        SegmentPredicate segmentPredicate = new SegmentPredicate("custom", config);
+        segmentPredicate.setId(1L);
+        segmentPredicate.load();
+        return segmentPredicate;
     }
 
     public static Map<String, Object> createJobDetailMap() {

--- a/service/src/test/java/org/apache/griffin/core/util/PredicatorMock.java
+++ b/service/src/test/java/org/apache/griffin/core/util/PredicatorMock.java
@@ -11,6 +11,6 @@ public class PredicatorMock implements Predicator {
 
     @Override
     public boolean predicate() throws IOException {
-        return false;
+        return true;
     }
 }

--- a/service/src/test/java/org/apache/griffin/core/util/PredicatorMock.java
+++ b/service/src/test/java/org/apache/griffin/core/util/PredicatorMock.java
@@ -1,0 +1,16 @@
+package org.apache.griffin.core.util;
+
+import org.apache.griffin.core.job.Predicator;
+import org.apache.griffin.core.job.entity.SegmentPredicate;
+
+import java.io.IOException;
+
+public class PredicatorMock implements Predicator {
+    public PredicatorMock(SegmentPredicate segmentPredicate) {
+    }
+
+    @Override
+    public boolean predicate() throws IOException {
+        return false;
+    }
+}


### PR DESCRIPTION
Classifier "exec" added to spring-boot-maven-plugin for possibility use service as a library. This will allow to create custom predicates without recompiling Griffin-service module. 

The approach to deserialisation in SparkSubmit changed for possibility to use all fields of SegmentPredicate in custom predicates.