### PR TITLE
Bugfix - the sinks are not saved in the database

### DIFF
--- a/service/src/main/java/org/apache/griffin/core/measure/entity/DataConnector.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/entity/DataConnector.java
@@ -29,17 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
-import javax.persistence.PostLoad;
-import javax.persistence.PrePersist;
-import javax.persistence.PreUpdate;
-import javax.persistence.Transient;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 import org.apache.griffin.core.job.entity.SegmentPredicate;
@@ -88,6 +78,7 @@ public class DataConnector extends AbstractAuditableEntity {
     private String defaultDataUnit = "365000d";
 
     @JsonIgnore
+    @Column(length = 20480)
     private String config;
 
     @Transient

--- a/service/src/main/java/org/apache/griffin/core/measure/entity/GriffinMeasure.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/entity/GriffinMeasure.java
@@ -182,6 +182,7 @@ public class GriffinMeasure extends Measure {
     @PrePersist
     @PreUpdate
     public void save() throws JsonProcessingException {
+        super.save();
         if (ruleDescriptionMap != null) {
             this.ruleDescription = JsonUtil.toJson(ruleDescriptionMap);
         }
@@ -189,6 +190,7 @@ public class GriffinMeasure extends Measure {
 
     @PostLoad
     public void load() throws IOException {
+        super.load();
         if (!StringUtils.isEmpty(ruleDescription)) {
             this.ruleDescriptionMap = JsonUtil.toEntity(ruleDescription,
                 new TypeReference<Map<String, Object>>() {

--- a/service/src/main/java/org/apache/griffin/core/measure/entity/Measure.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/entity/Measure.java
@@ -137,8 +137,6 @@ public abstract class Measure extends AbstractAuditableEntity {
     public void save() throws JsonProcessingException {
         if (sinksList != null) {
             this.sinks = JsonUtil.toJson(sinksList);
-        } else {
-            this.sinks = null;
         }
     }
 
@@ -147,8 +145,6 @@ public abstract class Measure extends AbstractAuditableEntity {
         if (!StringUtils.isEmpty(sinks)) {
             this.sinksList = JsonUtil.toEntity(sinks, new TypeReference<List<String>>() {
             });
-        } else {
-            this.sinksList = null;
         }
     }
 


### PR DESCRIPTION
1. Bugfix - the sinks are not saved in the database
2. The size of the dataconnector.config field in the database has been increased. The default size (256) is not enough when using custom data sources.