### PR TITLE
GRIFFIN-263 Use independent logger for griffin

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/Loggable.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Loggable.scala
@@ -18,11 +18,22 @@ under the License.
 */
 package org.apache.griffin.measure
 
-import org.slf4j.LoggerFactory
+import org.apache.log4j.Level
+import org.apache.log4j.Logger
 
 trait Loggable {
 
-  @transient private lazy val logger = LoggerFactory.getLogger(getClass)
+  @transient private lazy val logger = Logger.getLogger(getClass)
+
+  @transient protected lazy val griffinLogger = Logger.getLogger("org.apache.griffin")
+
+  def getGriffinLogLevel(): Level = {
+    var logger = griffinLogger
+    while (logger != null && logger.getLevel == null) {
+      logger = logger.getParent.asInstanceOf[Logger]
+    }
+    logger.getLevel
+  }
 
   protected def info(msg: String): Unit = {
     logger.info(msg)

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
@@ -57,7 +57,9 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
     conf.setAll(sparkParam.getConfig)
     conf.set("spark.sql.crossJoin.enabled", "true")
     sparkSession = SparkSession.builder().config(conf).enableHiveSupport().getOrCreate()
+    var logLevel = getGriffinLogLevel()
     sparkSession.sparkContext.setLogLevel(sparkParam.getLogLevel)
+    griffinLogger.setLevel(logLevel)
     sqlContext = sparkSession.sqlContext
 
     // register udf

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
@@ -63,7 +63,9 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
     conf.setAll(sparkParam.getConfig)
     conf.set("spark.sql.crossJoin.enabled", "true")
     sparkSession = SparkSession.builder().config(conf).enableHiveSupport().getOrCreate()
+    var logLevel = getGriffinLogLevel()
     sparkSession.sparkContext.setLogLevel(sparkParam.getLogLevel)
+    griffinLogger.setLevel(logLevel)
     sqlContext = sparkSession.sqlContext
 
     // clear checkpoint directory


### PR DESCRIPTION
When we run DQJob,  user can only set logger level for spark execution engine. 
```java
  sparkSession.sparkContext.setLogLevel(sparkParam.getLogLevel)
```

We have independent logger for griffin, which would be very helpful to debug or understand the internal of griffin. 
```java
var logLevel = getGriffinLogLevel() sparkSession.sparkContext.setLogLevel(sparkParam.getLogLevel) griffinLogger.setLevel(logLevel)
```
 