### PR TITLE
[GRIFFIN-275] [Measure] Post data to ElasticSearch failed

### DIFF
--- a/measure/pom.xml
+++ b/measure/pom.xml
@@ -74,6 +74,16 @@ under the License.
             <artifactId>spark-hive_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -167,6 +177,13 @@ under the License.
             <artifactId>spark-testing-base_${scala.binary.version}</artifactId>
             <version>${spark.version}_${spark.testing.version}</version>
             <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Griffin uses apache httpclient 4.5.2 to post data to Elastic Search. 
There are conflict i