### PR TITLE
GRIFFIN-279 Upgrade Spring boot to 2.1.7.RELEASE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@
 
 language: java scala node_js
 
+sudo: required
+
+services:
+  - docker
+
+env:
+  - COMPOSE_FILE=griffin-doc/docker/compose/docker-compose-batch.yml
+
 jdk:
   - oraclejdk8
 scala:
@@ -30,5 +38,7 @@ install:
   - npm install -g bower
 
 # keep 30, need change according to ci logs.
-script: travis_wait 30 mvn clean verify -q
+script:
+  - docker-compose up -d 
+  - travis_wait 30 mvn clean verify -q
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,12 @@ cache:
 install:
   - npm install -g bower
 
+before_script:
+  - MAVEN_SKIP_RC=true 
+  - MAVEN_OPTS="-Xmx2g"
+  - docker-compose up -d 
+
 # keep 30, need change according to ci logs.
 script:
-  - docker-compose up -d 
-  - travis_wait 30 mvn -q install
+  - travis_wait 50 mvn clean test verify -q
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ install:
 # keep 30, need change according to ci logs.
 script:
   - docker-compose up -d 
-  - travis_wait 30 mvn clean verify -q
+  - travis_wait 30 mvn install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ install:
 # keep 30, need change according to ci logs.
 script:
   - docker-compose up -d 
-  - travis_wait 30 mvn clean verify -q
+  - mvn clean test verify -q
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ install:
 # keep 30, need change according to ci logs.
 script:
   - docker-compose up -d 
-  - mvn clean test verify
+  - travis_wait 30 mvn clean verify -q
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ scala:
   - 2.10.6
 node_js:
   - "6"
+
 git:
   quiet: true
+
 cache:
   directories:
   - $HOME/.m2
@@ -40,5 +42,5 @@ install:
 # keep 30, need change according to ci logs.
 script:
   - docker-compose up -d 
-  - travis_wait 30 mvn install
+  - travis_wait 30 mvn -q install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ install:
 # keep 30, need change according to ci logs.
 script:
   - docker-compose up -d 
-  - mvn clean test verify -q
+  - mvn clean test verify
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -35,21 +35,20 @@ under the License.
         <hadoop.version>2.7.1</hadoop.version>
         <hive.version>2.2.0</hive.version>
         <scala.version>2.10</scala.version>
-        <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
-        <spring.security.kerberos.version>1.0.0.RELEASE</spring.security.kerberos.version>
+        <spring.boot.version>2.1.7.RELEASE</spring.boot.version>
+        <spring.security.kerberos.version>1.0.1.RELEASE</spring.security.kerberos.version>
         <confluent.version>3.2.0</confluent.version>
         <quartz.version>2.2.2</quartz.version>
         <start-class>org.apache.griffin.core.GriffinWebApplication</start-class>
-        <powermock.version>1.6.6</powermock.version>
-        <mockito.version>1.10.19</mockito.version>
-        <spring-boot-maven-plugin.version>1.5.1.RELEASE</spring-boot-maven-plugin.version>
+        <powermock.version>2.0.2</powermock.version>
+        <spring-boot-maven-plugin.version>2.1.7.RELEASE</spring-boot-maven-plugin.version>
         <derby.version>10.14.1.0</derby.version>
         <eclipselink.version>2.6.0</eclipselink.version>
         <mysql.java.version>5.1.47</mysql.java.version>
         <postgresql.version>9.4.1212.jre7</postgresql.version>
         <livy.core.version>0.3.0</livy.core.version>
         <elasticsearch-rest-client.version>6.2.4</elasticsearch-rest-client.version>
-        <jackson-databind.version>2.6.3</jackson-databind.version>
+        <jackson-databind.version>2.9.9.3</jackson-databind.version>
     </properties>
 
     <repositories>
@@ -86,6 +85,23 @@ under the License.
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-json</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -251,6 +267,12 @@ under the License.
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -260,7 +282,7 @@ under the License.
 
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/service/src/main/java/org/apache/griffin/core/job/BatchJobOperatorImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/job/BatchJobOperatorImpl.java
@@ -19,13 +19,46 @@ under the License.
 
 package org.apache.griffin.core.job;
 
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_CONNECTOR_NAME;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_CRON_EXPRESSION;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_JOB_NAME;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_IS_NOT_IN_PAUSED_STATUS;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_IS_NOT_SCHEDULED;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_KEY_DOES_NOT_EXIST;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.MISSING_BASELINE_CONFIG;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
+import static org.quartz.CronExpression.isValidExpression;
+import static org.quartz.JobKey.jobKey;
+import static org.quartz.Trigger.TriggerState;
+import static org.quartz.Trigger.TriggerState.BLOCKED;
+import static org.quartz.Trigger.TriggerState.NORMAL;
+import static org.quartz.Trigger.TriggerState.PAUSED;
+import static org.quartz.TriggerKey.triggerKey;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.*;
+import org.apache.griffin.core.job.entity.AbstractJob;
+import org.apache.griffin.core.job.entity.BatchJob;
+import org.apache.griffin.core.job.entity.JobDataSegment;
+import org.apache.griffin.core.job.entity.JobHealth;
+import org.apache.griffin.core.job.entity.JobInstanceBean;
+import org.apache.griffin.core.job.entity.JobState;
+import org.apache.griffin.core.job.entity.LivySessionStates;
 import org.apache.griffin.core.job.repo.BatchJobRepo;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
 import org.apache.griffin.core.measure.entity.DataSource;
 import org.apache.griffin.core.measure.entity.GriffinMeasure;
-import org.quartz.*;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,16 +68,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-
-import java.util.*;
-
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.*;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
-import static org.quartz.CronExpression.isValidExpression;
-import static org.quartz.JobKey.jobKey;
-import static org.quartz.Trigger.TriggerState;
-import static org.quartz.Trigger.TriggerState.*;
-import static org.quartz.TriggerKey.triggerKey;
 
 @Service
 public class BatchJobOperatorImpl implements JobOperator {

--- a/service/src/main/java/org/apache/griffin/core/job/BatchJobOperatorImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/job/BatchJobOperatorImpl.java
@@ -19,54 +19,32 @@ under the License.
 
 package org.apache.griffin.core.job;
 
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_CONNECTOR_NAME;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_CRON_EXPRESSION;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_JOB_NAME;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_IS_NOT_IN_PAUSED_STATUS;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_IS_NOT_SCHEDULED;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_KEY_DOES_NOT_EXIST;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.MISSING_BASELINE_CONFIG;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
-import static org.quartz.CronExpression.isValidExpression;
-import static org.quartz.JobKey.jobKey;
-import static org.quartz.Trigger.TriggerState;
-import static org.quartz.Trigger.TriggerState.BLOCKED;
-import static org.quartz.Trigger.TriggerState.NORMAL;
-import static org.quartz.Trigger.TriggerState.PAUSED;
-import static org.quartz.TriggerKey.triggerKey;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.AbstractJob;
-import org.apache.griffin.core.job.entity.BatchJob;
-import org.apache.griffin.core.job.entity.JobDataSegment;
-import org.apache.griffin.core.job.entity.JobHealth;
-import org.apache.griffin.core.job.entity.JobInstanceBean;
-import org.apache.griffin.core.job.entity.JobState;
-import org.apache.griffin.core.job.entity.LivySessionStates;
+import org.apache.griffin.core.job.entity.*;
 import org.apache.griffin.core.job.repo.BatchJobRepo;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
 import org.apache.griffin.core.measure.entity.DataSource;
 import org.apache.griffin.core.measure.entity.GriffinMeasure;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.Trigger;
-import org.quartz.TriggerKey;
+import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.*;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
+import static org.quartz.CronExpression.isValidExpression;
+import static org.quartz.JobKey.jobKey;
+import static org.quartz.Trigger.TriggerState;
+import static org.quartz.Trigger.TriggerState.*;
+import static org.quartz.TriggerKey.triggerKey;
 
 @Service
 public class BatchJobOperatorImpl implements JobOperator {
@@ -74,6 +52,7 @@ public class BatchJobOperatorImpl implements JobOperator {
             .getLogger(BatchJobOperatorImpl.class);
 
     @Autowired
+    @Qualifier("schedulerFactoryBean")
     private SchedulerFactoryBean factory;
     @Autowired
     private JobInstanceRepo instanceRepo;
@@ -309,7 +288,7 @@ public class BatchJobOperatorImpl implements JobOperator {
             boolean status = pauseJobInstance(instance, deletedInstances);
             pauseStatus = pauseStatus && status;
         }
-        instanceRepo.save(deletedInstances);
+        instanceRepo.saveAll(deletedInstances);
         return pauseStatus;
     }
 

--- a/service/src/main/java/org/apache/griffin/core/job/JobInstance.java
+++ b/service/src/main/java/org/apache/griffin/core/job/JobInstance.java
@@ -19,29 +19,6 @@ under the License.
 
 package org.apache.griffin.core.job;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.*;
-import org.apache.griffin.core.job.repo.JobInstanceRepo;
-import org.apache.griffin.core.job.repo.JobRepo;
-import org.apache.griffin.core.measure.entity.DataConnector;
-import org.apache.griffin.core.measure.entity.DataSource;
-import org.apache.griffin.core.measure.entity.GriffinMeasure;
-import org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType;
-import org.apache.griffin.core.measure.repo.GriffinMeasureRepo;
-import org.apache.griffin.core.util.TimeUtil;
-import org.quartz.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.env.Environment;
-import org.springframework.scheduling.quartz.SchedulerFactoryBean;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
-import java.util.*;
-
 import static org.apache.griffin.core.exception.GriffinExceptionMessage.QUARTZ_JOB_ALREADY_EXIST;
 import static org.apache.griffin.core.job.JobServiceImpl.GRIFFIN_JOB_ID;
 import static org.apache.griffin.core.job.entity.LivySessionStates.State.FINDING;
@@ -54,6 +31,49 @@ import static org.quartz.JobKey.jobKey;
 import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static org.quartz.TriggerKey.triggerKey;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.griffin.core.exception.GriffinException;
+import org.apache.griffin.core.job.entity.AbstractJob;
+import org.apache.griffin.core.job.entity.JobDataSegment;
+import org.apache.griffin.core.job.entity.JobInstanceBean;
+import org.apache.griffin.core.job.entity.SegmentPredicate;
+import org.apache.griffin.core.job.entity.SegmentRange;
+import org.apache.griffin.core.job.repo.JobInstanceRepo;
+import org.apache.griffin.core.job.repo.JobRepo;
+import org.apache.griffin.core.measure.entity.DataConnector;
+import org.apache.griffin.core.measure.entity.DataSource;
+import org.apache.griffin.core.measure.entity.GriffinMeasure;
+import org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType;
+import org.apache.griffin.core.measure.repo.GriffinMeasureRepo;
+import org.apache.griffin.core.util.TimeUtil;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.PersistJobDataAfterExecution;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.transaction.annotation.Transactional;
 
 @PersistJobDataAfterExecution
 @DisallowConcurrentExecution

--- a/service/src/main/java/org/apache/griffin/core/job/JobInstance.java
+++ b/service/src/main/java/org/apache/griffin/core/job/JobInstance.java
@@ -19,6 +19,29 @@ under the License.
 
 package org.apache.griffin.core.job;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.griffin.core.exception.GriffinException;
+import org.apache.griffin.core.job.entity.*;
+import org.apache.griffin.core.job.repo.JobInstanceRepo;
+import org.apache.griffin.core.job.repo.JobRepo;
+import org.apache.griffin.core.measure.entity.DataConnector;
+import org.apache.griffin.core.measure.entity.DataSource;
+import org.apache.griffin.core.measure.entity.GriffinMeasure;
+import org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType;
+import org.apache.griffin.core.measure.repo.GriffinMeasureRepo;
+import org.apache.griffin.core.util.TimeUtil;
+import org.quartz.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.*;
+
 import static org.apache.griffin.core.exception.GriffinExceptionMessage.QUARTZ_JOB_ALREADY_EXIST;
 import static org.apache.griffin.core.job.JobServiceImpl.GRIFFIN_JOB_ID;
 import static org.apache.griffin.core.job.entity.LivySessionStates.State.FINDING;
@@ -31,48 +54,6 @@ import static org.quartz.JobKey.jobKey;
 import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static org.quartz.TriggerKey.triggerKey;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.AbstractJob;
-import org.apache.griffin.core.job.entity.JobDataSegment;
-import org.apache.griffin.core.job.entity.JobInstanceBean;
-import org.apache.griffin.core.job.entity.SegmentPredicate;
-import org.apache.griffin.core.job.entity.SegmentRange;
-import org.apache.griffin.core.job.repo.JobInstanceRepo;
-import org.apache.griffin.core.job.repo.JobRepo;
-import org.apache.griffin.core.measure.entity.DataConnector;
-import org.apache.griffin.core.measure.entity.DataSource;
-import org.apache.griffin.core.measure.entity.GriffinMeasure;
-import org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType;
-import org.apache.griffin.core.measure.repo.GriffinMeasureRepo;
-import org.apache.griffin.core.util.TimeUtil;
-import org.quartz.DisallowConcurrentExecution;
-import org.quartz.Job;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobKey;
-import org.quartz.PersistJobDataAfterExecution;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.Trigger;
-import org.quartz.TriggerKey;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.scheduling.quartz.SchedulerFactoryBean;
-import org.springframework.transaction.annotation.Transactional;
 
 @PersistJobDataAfterExecution
 @DisallowConcurrentExecution
@@ -91,6 +72,7 @@ public class JobInstance implements Job {
             "checkdonefile.schedule";
 
     @Autowired
+    @Qualifier("schedulerFactoryBean")
     private SchedulerFactoryBean factory;
     @Autowired
     private GriffinMeasureRepo measureRepo;

--- a/service/src/main/java/org/apache/griffin/core/job/JobServiceImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/job/JobServiceImpl.java
@@ -19,13 +19,56 @@ under the License.
 
 package org.apache.griffin.core.job;
 
+import static java.util.TimeZone.getTimeZone;
+import static org.apache.griffin.core.config.EnvConfig.ENV_BATCH;
+import static org.apache.griffin.core.config.EnvConfig.ENV_STREAMING;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INSTANCE_ID_DOES_NOT_EXIST;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_MEASURE_ID;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_ID_DOES_NOT_EXIST;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_NAME_DOES_NOT_EXIST;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_TYPE_DOES_NOT_SUPPORT;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.MEASURE_TYPE_DOES_NOT_SUPPORT;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.NO_SUCH_JOB_ACTION;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.QUARTZ_JOB_ALREADY_EXIST;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.BUSY;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.DEAD;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.IDLE;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.NOT_STARTED;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.RECOVERING;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.RUNNING;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.STARTING;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.SUCCESS;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.UNKNOWN;
+import static org.apache.griffin.core.job.entity.LivySessionStates.isActive;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
+import static org.quartz.CronScheduleBuilder.cronSchedule;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.JobKey.jobKey;
+import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
+import static org.quartz.TriggerBuilder.newTrigger;
+import static org.quartz.TriggerKey.triggerKey;
+
 import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.griffin.core.event.GriffinEventManager;
 import org.apache.griffin.core.event.JobEvent;
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.*;
+import org.apache.griffin.core.job.entity.AbstractJob;
+import org.apache.griffin.core.job.entity.BatchJob;
+import org.apache.griffin.core.job.entity.JobHealth;
+import org.apache.griffin.core.job.entity.JobInstanceBean;
+import org.apache.griffin.core.job.entity.JobState;
+import org.apache.griffin.core.job.entity.JobType;
+import org.apache.griffin.core.job.entity.LivySessionStates;
 import org.apache.griffin.core.job.entity.LivySessionStates.State;
+import org.apache.griffin.core.job.entity.StreamingJob;
 import org.apache.griffin.core.job.repo.BatchJobRepo;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
 import org.apache.griffin.core.job.repo.JobRepo;
@@ -37,7 +80,14 @@ import org.apache.griffin.core.util.JsonUtil;
 import org.apache.griffin.core.util.YarnNetUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.quartz.*;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,26 +102,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.TimeZone;
-
-import static java.util.TimeZone.getTimeZone;
-import static org.apache.griffin.core.config.EnvConfig.ENV_BATCH;
-import static org.apache.griffin.core.config.EnvConfig.ENV_STREAMING;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.*;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.*;
-import static org.apache.griffin.core.job.entity.LivySessionStates.isActive;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
-import static org.quartz.CronScheduleBuilder.cronSchedule;
-import static org.quartz.JobBuilder.newJob;
-import static org.quartz.JobKey.jobKey;
-import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
-import static org.quartz.TriggerBuilder.newTrigger;
-import static org.quartz.TriggerKey.triggerKey;
 
 @Service
 public class JobServiceImpl implements JobService {

--- a/service/src/main/java/org/apache/griffin/core/job/JobServiceImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/job/JobServiceImpl.java
@@ -19,56 +19,13 @@ under the License.
 
 package org.apache.griffin.core.job;
 
-import static java.util.TimeZone.getTimeZone;
-import static org.apache.griffin.core.config.EnvConfig.ENV_BATCH;
-import static org.apache.griffin.core.config.EnvConfig.ENV_STREAMING;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INSTANCE_ID_DOES_NOT_EXIST;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_MEASURE_ID;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_ID_DOES_NOT_EXIST;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_NAME_DOES_NOT_EXIST;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.JOB_TYPE_DOES_NOT_SUPPORT;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.MEASURE_TYPE_DOES_NOT_SUPPORT;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.NO_SUCH_JOB_ACTION;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.QUARTZ_JOB_ALREADY_EXIST;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.BUSY;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.DEAD;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.IDLE;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.NOT_STARTED;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.RECOVERING;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.RUNNING;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.STARTING;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.SUCCESS;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.UNKNOWN;
-import static org.apache.griffin.core.job.entity.LivySessionStates.isActive;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
-import static org.quartz.CronScheduleBuilder.cronSchedule;
-import static org.quartz.JobBuilder.newJob;
-import static org.quartz.JobKey.jobKey;
-import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
-import static org.quartz.TriggerBuilder.newTrigger;
-import static org.quartz.TriggerKey.triggerKey;
-
 import com.fasterxml.jackson.core.type.TypeReference;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.TimeZone;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.griffin.core.event.GriffinEventManager;
 import org.apache.griffin.core.event.JobEvent;
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.AbstractJob;
-import org.apache.griffin.core.job.entity.BatchJob;
-import org.apache.griffin.core.job.entity.JobHealth;
-import org.apache.griffin.core.job.entity.JobInstanceBean;
-import org.apache.griffin.core.job.entity.JobState;
-import org.apache.griffin.core.job.entity.JobType;
-import org.apache.griffin.core.job.entity.LivySessionStates;
+import org.apache.griffin.core.job.entity.*;
 import org.apache.griffin.core.job.entity.LivySessionStates.State;
-import org.apache.griffin.core.job.entity.StreamingJob;
 import org.apache.griffin.core.job.repo.BatchJobRepo;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
 import org.apache.griffin.core.job.repo.JobRepo;
@@ -80,17 +37,11 @@ import org.apache.griffin.core.util.JsonUtil;
 import org.apache.griffin.core.util.YarnNetUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
-import org.quartz.TriggerKey;
+import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -101,7 +52,26 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
+import static java.util.TimeZone.getTimeZone;
+import static org.apache.griffin.core.config.EnvConfig.ENV_BATCH;
+import static org.apache.griffin.core.config.EnvConfig.ENV_STREAMING;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.*;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.*;
+import static org.apache.griffin.core.job.entity.LivySessionStates.isActive;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.BATCH;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
+import static org.quartz.CronScheduleBuilder.cronSchedule;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.JobKey.jobKey;
+import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
+import static org.quartz.TriggerBuilder.newTrigger;
+import static org.quartz.TriggerKey.triggerKey;
 
 @Service
 public class JobServiceImpl implements JobService {
@@ -114,6 +84,7 @@ public class JobServiceImpl implements JobService {
     static final String STOP = "stop";
 
     @Autowired
+    @Qualifier("schedulerFactoryBean")
     private SchedulerFactoryBean factory;
     @Autowired
     private JobInstanceRepo instanceRepo;

--- a/service/src/main/java/org/apache/griffin/core/job/StreamingJobOperatorImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/job/StreamingJobOperatorImpl.java
@@ -19,8 +19,25 @@ under the License.
 
 package org.apache.griffin.core.job;
 
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_JOB_NAME;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.STREAMING_JOB_IS_RUNNING;
+import static org.apache.griffin.core.job.JobServiceImpl.START;
+import static org.apache.griffin.core.job.JobServiceImpl.STOP;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.STOPPED;
+import static org.apache.griffin.core.job.entity.LivySessionStates.convert2QuartzState;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
+import static org.quartz.TriggerKey.triggerKey;
+
+import java.util.List;
+import javax.annotation.PostConstruct;
+
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.*;
+import org.apache.griffin.core.job.entity.AbstractJob;
+import org.apache.griffin.core.job.entity.JobHealth;
+import org.apache.griffin.core.job.entity.JobInstanceBean;
+import org.apache.griffin.core.job.entity.JobState;
+import org.apache.griffin.core.job.entity.StreamingJob;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
 import org.apache.griffin.core.job.repo.StreamingJobRepo;
 import org.apache.griffin.core.measure.entity.GriffinMeasure;
@@ -40,19 +57,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
-
-import javax.annotation.PostConstruct;
-import java.util.List;
-
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_JOB_NAME;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.STREAMING_JOB_IS_RUNNING;
-import static org.apache.griffin.core.job.JobServiceImpl.START;
-import static org.apache.griffin.core.job.JobServiceImpl.STOP;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.STOPPED;
-import static org.apache.griffin.core.job.entity.LivySessionStates.convert2QuartzState;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
-import static org.quartz.TriggerKey.triggerKey;
 
 @Service
 public class StreamingJobOperatorImpl implements JobOperator {

--- a/service/src/main/java/org/apache/griffin/core/job/StreamingJobOperatorImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/job/StreamingJobOperatorImpl.java
@@ -19,25 +19,8 @@ under the License.
 
 package org.apache.griffin.core.job;
 
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_JOB_NAME;
-import static org.apache.griffin.core.exception.GriffinExceptionMessage.STREAMING_JOB_IS_RUNNING;
-import static org.apache.griffin.core.job.JobServiceImpl.START;
-import static org.apache.griffin.core.job.JobServiceImpl.STOP;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State;
-import static org.apache.griffin.core.job.entity.LivySessionStates.State.STOPPED;
-import static org.apache.griffin.core.job.entity.LivySessionStates.convert2QuartzState;
-import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
-import static org.quartz.TriggerKey.triggerKey;
-
-import java.util.List;
-import javax.annotation.PostConstruct;
-
 import org.apache.griffin.core.exception.GriffinException;
-import org.apache.griffin.core.job.entity.AbstractJob;
-import org.apache.griffin.core.job.entity.JobHealth;
-import org.apache.griffin.core.job.entity.JobInstanceBean;
-import org.apache.griffin.core.job.entity.JobState;
-import org.apache.griffin.core.job.entity.StreamingJob;
+import org.apache.griffin.core.job.entity.*;
 import org.apache.griffin.core.job.repo.JobInstanceRepo;
 import org.apache.griffin.core.job.repo.StreamingJobRepo;
 import org.apache.griffin.core.measure.entity.GriffinMeasure;
@@ -49,6 +32,7 @@ import org.quartz.TriggerKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.stereotype.Service;
@@ -56,6 +40,19 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.INVALID_JOB_NAME;
+import static org.apache.griffin.core.exception.GriffinExceptionMessage.STREAMING_JOB_IS_RUNNING;
+import static org.apache.griffin.core.job.JobServiceImpl.START;
+import static org.apache.griffin.core.job.JobServiceImpl.STOP;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State;
+import static org.apache.griffin.core.job.entity.LivySessionStates.State.STOPPED;
+import static org.apache.griffin.core.job.entity.LivySessionStates.convert2QuartzState;
+import static org.apache.griffin.core.measure.entity.GriffinMeasure.ProcessType.STREAMING;
+import static org.quartz.TriggerKey.triggerKey;
 
 @Service
 public class StreamingJobOperatorImpl implements JobOperator {
@@ -70,6 +67,7 @@ public class StreamingJobOperatorImpl implements JobOperator {
     @Autowired
     private JobInstanceRepo instanceRepo;
     @Autowired
+    @Qualifier("schedulerFactoryBean")
     private SchedulerFactoryBean factory;
     @Autowired
     private LivyTaskSubmitHelper livyTaskSubmitHelper;

--- a/service/src/main/java/org/apache/griffin/core/job/repo/BaseJpaRepository.java
+++ b/service/src/main/java/org/apache/griffin/core/job/repo/BaseJpaRepository.java
@@ -19,22 +19,12 @@ under the License.
 
 package org.apache.griffin.core.job.repo;
 
-import org.apache.griffin.core.job.entity.AbstractJob;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
 
-import java.util.List;
-
-public interface JobRepo<T extends AbstractJob> extends BaseJpaRepository<T, Long> {
-
-    @Query("select count(j) from #{#entityName} j " +
-            "where j.jobName = ?1 and j.deleted = ?2")
-    int countByJobNameAndDeleted(String jobName, Boolean deleted);
-
-    List<T> findByDeleted(boolean deleted);
-
-    List<T> findByJobNameAndDeleted(String jobName, boolean deleted);
-
-    List<T> findByMeasureIdAndDeleted(Long measureId, boolean deleted);
-
-    T findByIdAndDeleted(Long jobId, boolean deleted);
+@NoRepositoryBean
+public interface BaseJpaRepository<T, ID> extends JpaRepository<T, ID> {
+    default T findOne(ID id) {
+        return (T) findById(id).orElse(null);
+    }
 }

--- a/service/src/main/java/org/apache/griffin/core/job/repo/JobInstanceRepo.java
+++ b/service/src/main/java/org/apache/griffin/core/job/repo/JobInstanceRepo.java
@@ -18,19 +18,18 @@ under the License.
 */
 package org.apache.griffin.core.job.repo;
 
-import static org.apache.griffin.core.job.entity.LivySessionStates.State;
-
-import java.util.List;
-
 import org.apache.griffin.core.job.entity.JobInstanceBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+import static org.apache.griffin.core.job.entity.LivySessionStates.State;
+
 public interface JobInstanceRepo
-        extends CrudRepository<JobInstanceBean, Long> {
+        extends BaseJpaRepository<JobInstanceBean, Long> {
 
     JobInstanceBean findByPredicateName(String name);
 

--- a/service/src/main/java/org/apache/griffin/core/measure/repo/MeasureRepo.java
+++ b/service/src/main/java/org/apache/griffin/core/measure/repo/MeasureRepo.java
@@ -20,11 +20,11 @@ under the License.
 package org.apache.griffin.core.measure.repo;
 
 
-import java.util.List;
-
+import org.apache.griffin.core.job.repo.BaseJpaRepository;
 import org.apache.griffin.core.measure.entity.Measure;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
 
 /**
  * Interface to access measure repository
@@ -32,7 +32,7 @@ import org.springframework.data.repository.CrudRepository;
  * @param <T> Measure and its subclass
  */
 public interface MeasureRepo<T extends Measure>
-        extends CrudRepository<T, Long> {
+        extends BaseJpaRepository<T, Long> {
 
     /**
      * search repository by name and deletion state

--- a/service/src/test/java/org/apache/griffin/core/job/JobInstanceTest.java
+++ b/service/src/test/java/org/apache/griffin/core/job/JobInstanceTest.java
@@ -52,7 +52,6 @@ import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.Trigger;
 import org.quartz.TriggerKey;
-import org.quartz.impl.triggers.AbstractTrigger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestConfiguration;

--- a/service/src/test/java/org/apache/griffin/core/job/SparkSubmitJobTest.java
+++ b/service/src/test/java/org/apache/griffin/core/job/SparkSubmitJobTest.java
@@ -47,7 +47,10 @@ import java.util.Properties;
 
 import static org.apache.griffin.core.util.EntityMocksHelper.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 
 
 @RunWith(SpringRunner.class)

--- a/service/src/test/java/org/apache/griffin/core/job/SparkSubmitJobTest.java
+++ b/service/src/test/java/org/apache/griffin/core/job/SparkSubmitJobTest.java
@@ -19,16 +19,6 @@ under the License.
 
 package org.apache.griffin.core.job;
 
-import static org.apache.griffin.core.util.EntityMocksHelper.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Properties;
-
 import org.apache.griffin.core.config.PropertiesConfig;
 import org.apache.griffin.core.job.entity.JobInstanceBean;
 import org.apache.griffin.core.job.entity.SegmentPredicate;
@@ -40,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +40,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.apache.griffin.core.util.EntityMocksHelper.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 
 @RunWith(SpringRunner.class)

--- a/service/src/test/java/org/apache/griffin/core/metastore/hive/HiveMetaStoreServiceImplTest.java
+++ b/service/src/test/java/org/apache/griffin/core/metastore/hive/HiveMetaStoreServiceImplTest.java
@@ -22,6 +22,7 @@ package org.apache.griffin.core.metastore.hive;
 import org.apache.griffin.core.config.CacheConfig;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 import org.junit.Before;
@@ -186,7 +187,7 @@ public class HiveMetaStoreServiceImplTest {
     public void testGetTableForException() throws Exception {
         String dbName = "default";
         String tableName = "tableName";
-        given(client.getTable(dbName, tableName)).willThrow(Exception.class);
+        given(client.getTable(dbName, tableName)).willThrow(NoSuchObjectException.class);
         doNothing().when(client).reconnect();
         assertTrue(service.getTable(dbName, tableName) == null);
         verify(client).reconnect();

--- a/service/src/test/java/org/apache/griffin/core/metric/MetricStoreImplTest.java
+++ b/service/src/test/java/org/apache/griffin/core/metric/MetricStoreImplTest.java
@@ -107,11 +107,11 @@ public class MetricStoreImplTest {
         given(httpEntityMock.getContent()).willReturn(is);
 
         //when
-        MetricStoreImpl metricStore = new MetricStoreImpl("", 0, "", "", "");
+        MetricStoreImpl metricStore = new MetricStoreImpl("localhost", 0, "", "", "");
         MetricValue metric = metricStore.getMetric("application_1549876136110_0018");
 
         //then
-        PowerMockito.verifyStatic();
+        //PowerMockito.verifyStatic();
         assertEquals(expectedMetric, metric);
     }
 

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -24,7 +24,7 @@ spring.datasource.password=test
 spring.datasource.schema=classpath:Init_quartz_h2_test.sql
 spring.jpa.show-sql=true
 # Hive metastore
-hive.metastore.uris=thrift://localhost:9083
+hive.metastore.uris=thrift://localhost:39083
 hive.metastore.dbname=default
 hive.hmshandler.retry.attempts=15
 hive.hmshandler.retry.interval=2000ms
@@ -44,8 +44,8 @@ predicate.job.repeat.count=12
 external.config.location=
 # external BATCH or STREAMING env
 external.env.location=
-# login strategy ("test" or "ldap")
-login.strategy=test
+# login strategy ("default" or "ldap")
+login.strategy=default
 # ldap
 ldap.url=ldap://hostname:port
 ldap.email=@example.com
@@ -61,3 +61,5 @@ elasticsearch.scheme=http
 internal.event.listeners=GriffinJobEventHook,GriffinTestJobEventHook
 
 logging.file=logs/griffin-service.log
+
+spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
As spring boot 1.x is end of life Aug 1st 2019, it would be great to migrate to 2.1.x.

Below is the announcement

https://spring.io/blog/2018/07/30/spring-boot-1-x-eol-aug-1st-2019

Migrate Guide is 

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide

 