### PR TITLE
[GRIFFIN-283] Move sink steps into TransformStep

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/DataFrameOpsDQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/DataFrameOpsDQStepBuilder.scala
@@ -29,7 +29,7 @@ case class DataFrameOpsDQStepBuilder() extends RuleParamStepBuilder {
     val name = getStepName(ruleParam.getOutDfName())
     val inputDfName = getStepName(ruleParam.getInDfName())
     val transformStep = DataFrameOpsTransformStep(
-      name, inputDfName, ruleParam.getRule, ruleParam.getDetails, ruleParam.getCache)
+      name, inputDfName, ruleParam.getRule, ruleParam.getDetails, None, ruleParam.getCache)
     transformStep +: buildDirectWriteSteps(ruleParam)
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/SparkSqlDQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/SparkSqlDQStepBuilder.scala
@@ -28,7 +28,7 @@ case class SparkSqlDQStepBuilder() extends RuleParamStepBuilder {
   def buildSteps(context: DQContext, ruleParam: RuleParam): Seq[DQStep] = {
     val name = getStepName(ruleParam.getOutDfName())
     val transformStep = SparkSqlTransformStep(
-      name, ruleParam.getRule, ruleParam.getDetails, ruleParam.getCache)
+      name, ruleParam.getRule, ruleParam.getDetails, None, ruleParam.getCache)
     transformStep +: buildDirectWriteSteps(ruleParam)
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/Expr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/Expr2DQSteps.scala
@@ -21,9 +21,10 @@ package org.apache.griffin.measure.step.builder.dsl.transform
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
 import org.apache.griffin.measure.configuration.enums._
-import org.apache.griffin.measure.context.{ContextId, DQContext, TimeRange}
+import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.dsl.expr.Expr
+import org.apache.griffin.measure.step.write.{MetricWriteStep, RecordWriteStep, WriteStep}
 
 trait Expr2DQSteps extends Loggable with Serializable {
 
@@ -31,7 +32,6 @@ trait Expr2DQSteps extends Loggable with Serializable {
   protected val emptyMap = Map[String, Any]()
 
   def getDQSteps(): Seq[DQStep]
-
 }
 
 /**

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
@@ -97,14 +97,15 @@ case class ProfilingExpr2DQSteps(context: DQContext,
           s"${fromClause} ${preGroupbyClause} ${groupbyClause} ${postGroupbyClause}"
       }
       val profilingName = ruleParam.getOutDfName()
-      val profilingTransStep = SparkSqlTransformStep(profilingName, profilingSql, details)
       val profilingMetricWriteStep = {
         val metricOpt = ruleParam.getOutputOpt(MetricOutputType)
         val mwName = metricOpt.flatMap(_.getNameOpt).getOrElse(ruleParam.getOutDfName())
         val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.default)
         MetricWriteStep(mwName, profilingName, flattenType)
       }
-      profilingTransStep :: profilingMetricWriteStep :: Nil
+      val profilingTransStep =
+        SparkSqlTransformStep(profilingName, profilingSql, details, Some(profilingMetricWriteStep))
+      profilingTransStep :: Nil
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/UniquenessExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/UniquenessExpr2DQSteps.scala
@@ -117,7 +117,7 @@ case class UniquenessExpr2DQSteps(context: DQContext,
         s"SELECT ${groupSelClause}, (COUNT(*) - 1) AS `${dupColName}` " +
           s"FROM `${joinedTableName}` GROUP BY ${groupSelClause}"
       }
-      val groupTransStep = SparkSqlTransformStep(groupTableName, groupSql, emptyMap, true)
+      val groupTransStep = SparkSqlTransformStep(groupTableName, groupSql, emptyMap, None, true)
       groupTransStep.parentSteps += joinedTransStep
 
       // 5. total metric
@@ -131,8 +131,9 @@ case class UniquenessExpr2DQSteps(context: DQContext,
              |FROM `${sourceName}` GROUP BY `${ConstantColumns.tmst}`
            """.stripMargin
       }
-      val totalTransStep = SparkSqlTransformStep(totalTableName, totalSql, emptyMap)
       val totalMetricWriteStep = MetricWriteStep(totalColName, totalTableName, EntriesFlattenType)
+      val totalTransStep =
+        SparkSqlTransformStep(totalTableName, totalSql, emptyMap, Some(totalMetricWriteStep))
 
       // 6. unique record
       val uniqueRecordTableName = "__uniqueRecord"
@@ -155,24 +156,21 @@ case class UniquenessExpr2DQSteps(context: DQContext,
              |FROM `${uniqueRecordTableName}` GROUP BY `${ConstantColumns.tmst}`
            """.stripMargin
       }
-      val uniqueTransStep = SparkSqlTransformStep(uniqueTableName, uniqueSql, emptyMap)
-      uniqueTransStep.parentSteps += uniqueRecordTransStep
-
       val uniqueMetricWriteStep =
         MetricWriteStep(uniqueColName, uniqueTableName, EntriesFlattenType)
+      val uniqueTransStep =
+        SparkSqlTransformStep(uniqueTableName, uniqueSql, emptyMap, Some(uniqueMetricWriteStep))
+      uniqueTransStep.parentSteps += uniqueRecordTransStep
 
       val transSteps1 = totalTransStep :: uniqueTransStep :: Nil
-      val writeSteps1 = totalMetricWriteStep :: uniqueMetricWriteStep :: Nil
 
       val duplicationArrayName = details.getString(_duplicationArray, "")
-      val (transSteps2, writeSteps2) = if (duplicationArrayName.nonEmpty) {
+      val transSteps2 = if (duplicationArrayName.nonEmpty) {
         // 8. duplicate record
         val dupRecordTableName = "__dupRecords"
         val dupRecordSql = {
           s"SELECT * FROM `${groupTableName}` WHERE `${dupColName}` > 0"
         }
-        val dupRecordTransStep =
-          SparkSqlTransformStep(dupRecordTableName, dupRecordSql, emptyMap, true)
 
         val dupRecordWriteStep = {
           val rwName =
@@ -181,6 +179,8 @@ case class UniquenessExpr2DQSteps(context: DQContext,
 
           RecordWriteStep(rwName, dupRecordTableName)
         }
+        val dupRecordTransStep =
+          SparkSqlTransformStep(dupRecordTableName, dupRecordSql, emptyMap, Some(dupRecordWriteStep), true)
 
         // 9. duplicate metric
         val dupMetricTableName = "__dupMetric"
@@ -201,18 +201,22 @@ case class UniquenessExpr2DQSteps(context: DQContext,
              |GROUP BY ${dupMetricGroupbyClause}
           """.stripMargin
         }
-        val dupMetricTransStep = SparkSqlTransformStep(dupMetricTableName, dupMetricSql, emptyMap)
-        dupMetricTransStep.parentSteps += dupRecordTransStep
         val dupMetricWriteStep = {
           MetricWriteStep(duplicationArrayName, dupMetricTableName, ArrayFlattenType)
         }
+        val dupMetricTransStep =
+          SparkSqlTransformStep(dupMetricTableName,
+            dupMetricSql,
+            emptyMap,
+            Some(dupMetricWriteStep)
+          )
+        dupMetricTransStep.parentSteps += dupRecordTransStep
 
-        (dupMetricTransStep :: Nil,
-          dupRecordWriteStep :: dupMetricWriteStep :: Nil)
-      } else (Nil, Nil)
+        dupMetricTransStep :: Nil
+      } else Nil
 
       // full steps
-      transSteps1 ++ transSteps2 ++ writeSteps1 ++ writeSteps2
+      transSteps1 ++ transSteps2
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
@@ -19,14 +19,16 @@ under the License.
 package org.apache.griffin.measure.step.transform
 
 import org.apache.griffin.measure.context.DQContext
+import org.apache.griffin.measure.step.write.WriteStep
 
 /**
   * data frame ops transform step
   */
-case class DataFrameOpsTransformStep(name: String,
+case class DataFrameOpsTransformStep[T <: WriteStep](name: String,
                                      inputDfName: String,
                                      rule: String,
                                      details: Map[String, Any],
+                                     writeStepOpt: Option[T] = None,
                                      cache: Boolean = false
                                     ) extends TransformStep {
 
@@ -43,7 +45,10 @@ case class DataFrameOpsTransformStep(name: String,
       }
       if (cache) context.dataFrameCache.cacheDataFrame(name, df)
       context.runTimeTableRegister.registerTable(name, df)
-      true
+      writeStepOpt match {
+        case Some(writeStep) => writeStep.execute(context)
+        case None => true
+      }
     } catch {
       case e: Throwable =>
         error(s"run data frame ops [ ${rule} ] error: ${e.getMessage}", e)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
@@ -19,23 +19,27 @@ under the License.
 package org.apache.griffin.measure.step.transform
 
 import org.apache.griffin.measure.context.DQContext
+import org.apache.griffin.measure.step.write.WriteStep
 
 /**
   * spark sql transform step
   */
-case class SparkSqlTransformStep(name: String,
-                                 rule: String,
-                                 details: Map[String, Any],
-                                 cache: Boolean = false
-                                ) extends TransformStep {
-
+case class SparkSqlTransformStep[T <: WriteStep](name: String,
+                                                 rule: String,
+                                                 details: Map[String, Any],
+                                                 writeStepOpt: Option[T] = None,
+                                                 cache: Boolean = false
+                                                ) extends TransformStep {
   def doExecute(context: DQContext): Boolean = {
     val sqlContext = context.sqlContext
     try {
       val df = sqlContext.sql(rule)
       if (cache) context.dataFrameCache.cacheDataFrame(name, df)
       context.runTimeTableRegister.registerTable(name, df)
-      true
+      writeStepOpt match {
+        case Some(writeStep) => writeStep.execute(context)
+        case None => true
+      }
     } catch {
       case e: Throwable =>
         error(s"run spark sql [ ${rule} ] error: ${e.getMessage}", e)

--- a/measure/src/test/scala/org/apache/griffin/measure/step/TransformStepTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/step/TransformStepTest.scala
@@ -19,14 +19,13 @@ under the License.
 package org.apache.griffin.measure.step
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest._
 
+import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.enums.BatchProcessType
 import org.apache.griffin.measure.context.ContextId
 import org.apache.griffin.measure.context.DQContext
-import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.step.transform.TransformStep
-
-import org.scalatest._
 
 class TransformStepTest extends FlatSpec with Matchers with DataFrameSuiteBase with Loggable {
 


### PR DESCRIPTION
Treat sink steps as a part of a transform step, so we can keep focus on transform step codes.
Also the sink steps and some other transform step could be executed concurrently.