### PR TITLE
[GRIFFIN-287]Use Jackson to parse json data

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -96,6 +96,11 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
When I build griffin with cdh's spark, the project compile failed because it can not find org.json:json jar in it's dependency tree.

So could we parse json data with jackson or some else jar instead of org.json:json ?