### PR TITLE
manul trigger job not work befor the timer first fired

### DIFF
--- a/service/src/main/java/org/apache/griffin/core/job/JobInstance.java
+++ b/service/src/main/java/org/apache/griffin/core/job/JobInstance.java
@@ -143,7 +143,11 @@ public class JobInstance implements Job {
         List<Trigger> triggers =
             (List<Trigger>) scheduler.getTriggersOfJob(jobKey);
         Date triggerTime = triggers.get(0).getPreviousFireTime();
-        jobStartTime = triggerTime.getTime();
+        if (triggerTime == null) {
+            jobStartTime = System.currentTimeMillis();
+        } else {
+            jobStartTime = triggerTime.getTime();
+        }
     }
 
     private void setSourcesPartitionsAndPredicates(List<DataSource> sources)


### PR DESCRIPTION
when you manual trigger the new job which not fired yet , triggerTime.getTime() will return a null value and cause null pointer exception.