### PR TITLE
[GRIFFIN-299]Add oracle jdk8 support in travis build phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+sudo: required
 language: java scala node_js
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+dist: trusty
 
 language: java scala node_js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-dist: trusty
-
 language: java scala node_js
 
 services:
@@ -21,9 +19,8 @@ services:
 env:
   - COMPOSE_FILE=griffin-doc/docker/compose/docker-compose-batch.yml
 
-
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
   - 2.10.6
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 # the License.
 
 language: java scala node_js
+dist: trusty
 
 services:
   - docker
@@ -20,7 +21,7 @@ env:
   - COMPOSE_FILE=griffin-doc/docker/compose/docker-compose-batch.yml
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 scala:
   - 2.10.6
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-sudo: required
 language: java scala node_js
-dist: trusty
 
 services:
   - docker
@@ -22,7 +20,7 @@ env:
   - COMPOSE_FILE=griffin-doc/docker/compose/docker-compose-batch.yml
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
   - 2.10.6
 node_js:


### PR DESCRIPTION
As Ubuntu Xenial has become the default Travis CI build environment, we may build fail. 

The workaround is to either add `dist: trusty` to your .travis.yml file or use `openjdk8`.