### PR TITLE
[GRIFFIN-304] Eliminate older contexts

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
@@ -18,7 +18,7 @@ under the License.
 */
 package org.apache.griffin.measure.context
 
-import org.apache.spark.sql.{Encoders, SparkSession, SQLContext}
+import org.apache.spark.sql.{Encoders, SparkSession}
 
 import org.apache.griffin.measure.configuration.dqdefinition._
 import org.apache.griffin.measure.configuration.enums._
@@ -37,10 +37,8 @@ case class DQContext(contextId: ContextId,
                      procType: ProcessType
                     )(@transient implicit val sparkSession: SparkSession) {
 
-  val sqlContext: SQLContext = sparkSession.sqlContext
-
   val compileTableRegister: CompileTableRegister = CompileTableRegister()
-  val runTimeTableRegister: RunTimeTableRegister = RunTimeTableRegister(sqlContext)
+  val runTimeTableRegister: RunTimeTableRegister = RunTimeTableRegister(sparkSession)
 
   val dataFrameCache: DataFrameCache = DataFrameCache()
 

--- a/measure/src/main/scala/org/apache/griffin/measure/context/TableRegister.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/TableRegister.scala
@@ -61,7 +61,7 @@ case class CompileTableRegister() extends TableRegister {}
 /**
   * register table name and create temp view during calculation
   */
-case class RunTimeTableRegister(@transient sqlContext: SparkSession) extends TableRegister {
+case class RunTimeTableRegister(@transient sparkSession: SparkSession) extends TableRegister {
 
   def registerTable(name: String, df: DataFrame): Unit = {
     registerTable(name)
@@ -70,13 +70,13 @@ case class RunTimeTableRegister(@transient sqlContext: SparkSession) extends Tab
 
   override def unregisterTable(name: String): Unit = {
     if (existsTable(name)) {
-      sqlContext.catalog.dropTempView(name)
+      sparkSession.catalog.dropTempView(name)
       tables -= name
     }
   }
   override def unregisterAllTables(): Unit = {
     val uts = getTables
-    uts.foreach(t => sqlContext.catalog.dropTempView(t))
+    uts.foreach(t => sparkSession.catalog.dropTempView(t))
     tables.clear
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/context/TableRegister.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/TableRegister.scala
@@ -61,7 +61,7 @@ case class CompileTableRegister() extends TableRegister {}
 /**
   * register table name and create temp view during calculation
   */
-case class RunTimeTableRegister(@transient sqlContext: SQLContext) extends TableRegister {
+case class RunTimeTableRegister(@transient sqlContext: SparkSession) extends TableRegister {
 
   def registerTable(name: String, df: DataFrame): Unit = {
     registerTable(name)
@@ -70,13 +70,13 @@ case class RunTimeTableRegister(@transient sqlContext: SQLContext) extends Table
 
   override def unregisterTable(name: String): Unit = {
     if (existsTable(name)) {
-      sqlContext.dropTempTable(name)
+      sqlContext.catalog.dropTempView(name)
       tables -= name
     }
   }
   override def unregisterAllTables(): Unit = {
     val uts = getTables
-    uts.foreach(t => sqlContext.dropTempTable(t))
+    uts.foreach(t => sqlContext.catalog.dropTempView(t))
     tables.clear
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/DataSourceFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/DataSourceFactory.scala
@@ -52,7 +52,7 @@ object DataSourceFactory extends Loggable {
 
     // for streaming data cache
     val streamingCacheClientOpt = StreamingCacheClientFactory.getClientOpt(
-      sparkSession.sqlContext, dataSourceParam.getCheckpointOpt, name, index, timestampStorage)
+      sparkSession, dataSourceParam.getCheckpointOpt, name, index, timestampStorage)
 
     val dataConnectors: Seq[DataConnector] = connectorParams.flatMap { connectorParam =>
       DataConnectorFactory.getDataConnector(sparkSession, ssc, connectorParam,

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClient.scala
@@ -43,7 +43,7 @@ import org.apache.griffin.measure.utils.ParamUtil._
 trait StreamingCacheClient
   extends StreamingOffsetCacheable with WithFanIn[Long] with Loggable with Serializable {
 
-  val sqlContext: SQLContext
+  val sqlContext: SparkSession
   val param: Map[String, Any]
   val dsName: String
   val index: Int

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClient.scala
@@ -43,7 +43,7 @@ import org.apache.griffin.measure.utils.ParamUtil._
 trait StreamingCacheClient
   extends StreamingOffsetCacheable with WithFanIn[Long] with Loggable with Serializable {
 
-  val sqlContext: SparkSession
+  val sparkSession: SparkSession
   val param: Map[String, Any]
   val dsName: String
   val index: Int
@@ -181,7 +181,7 @@ trait StreamingCacheClient
 
     // new cache data
     val newDfOpt = try {
-      val dfr = sqlContext.read
+      val dfr = sparkSession.read
       readDataFrameOpt(dfr, newFilePath).map(_.filter(filterStr))
     } catch {
       case e: Throwable =>
@@ -194,7 +194,7 @@ trait StreamingCacheClient
     val oldDfOpt = oldCacheIndexOpt.flatMap { idx =>
       val oldDfPath = s"${oldFilePath}/${idx}"
       try {
-        val dfr = sqlContext.read
+        val dfr = sparkSession.read
         readDataFrameOpt(dfr, oldDfPath).map(_.filter(filterStr))
       } catch {
         case e: Throwable =>
@@ -329,7 +329,7 @@ trait StreamingCacheClient
               val filterStr = s"`${ConstantColumns.tmst}` > ${cleanTime}"
               val updateDf = df.filter(filterStr)
 
-              val prlCount = sqlContext.sparkContext.defaultParallelism
+              val prlCount = sparkSession.sparkContext.defaultParallelism
               // repartition
               val repartitionedDf = updateDf.repartition(prlCount)
               val dfw = repartitionedDf.write.mode(SaveMode.Overwrite)

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClientFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClientFactory.scala
@@ -37,14 +37,14 @@ object StreamingCacheClientFactory extends Loggable {
 
   /**
     * create streaming cache client
-    * @param sqlContext     sqlContext in spark environment
+    * @param sparkSession     sparkSession in spark environment
     * @param checkpointOpt  data source checkpoint/cache config option
     * @param name           data source name
     * @param index          data source index
     * @param tmstCache      the same tmstCache instance inside a data source
     * @return               streaming cache client option
     */
-  def getClientOpt(sqlContext: SparkSession, checkpointOpt: Option[Map[String, Any]],
+  def getClientOpt(sparkSession: SparkSession, checkpointOpt: Option[Map[String, Any]],
                    name: String, index: Int, tmstCache: TimestampStorage
                   ): Option[StreamingCacheClient] = {
     checkpointOpt.flatMap { param =>
@@ -52,13 +52,13 @@ object StreamingCacheClientFactory extends Loggable {
         val tp = param.getString(_type, "")
         val dsCache = tp match {
           case ParquetRegex() =>
-            StreamingCacheParquetClient(sqlContext, param, name, index, tmstCache)
+            StreamingCacheParquetClient(sparkSession, param, name, index, tmstCache)
           case JsonRegex() =>
-            StreamingCacheJsonClient(sqlContext, param, name, index, tmstCache)
+            StreamingCacheJsonClient(sparkSession, param, name, index, tmstCache)
           case OrcRegex() =>
-            StreamingCacheOrcClient(sqlContext, param, name, index, tmstCache)
+            StreamingCacheOrcClient(sparkSession, param, name, index, tmstCache)
           case _ =>
-            StreamingCacheParquetClient(sqlContext, param, name, index, tmstCache)
+            StreamingCacheParquetClient(sparkSession, param, name, index, tmstCache)
         }
         Some(dsCache)
       } catch {

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClientFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheClientFactory.scala
@@ -18,7 +18,7 @@ under the License.
 */
 package org.apache.griffin.measure.datasource.cache
 
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.datasource.TimestampStorage
@@ -44,7 +44,7 @@ object StreamingCacheClientFactory extends Loggable {
     * @param tmstCache      the same tmstCache instance inside a data source
     * @return               streaming cache client option
     */
-  def getClientOpt(sqlContext: SQLContext, checkpointOpt: Option[Map[String, Any]],
+  def getClientOpt(sqlContext: SparkSession, checkpointOpt: Option[Map[String, Any]],
                    name: String, index: Int, tmstCache: TimestampStorage
                   ): Option[StreamingCacheClient] = {
     checkpointOpt.flatMap { param =>

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheJsonClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheJsonClient.scala
@@ -25,7 +25,7 @@ import org.apache.griffin.measure.datasource.TimestampStorage
 /**
   * data source cache in json format
   */
-case class StreamingCacheJsonClient(sqlContext: SparkSession, param: Map[String, Any],
+case class StreamingCacheJsonClient(sparkSession: SparkSession, param: Map[String, Any],
                                     dsName: String, index: Int, timestampStorage: TimestampStorage
                               ) extends StreamingCacheClient {
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheJsonClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheJsonClient.scala
@@ -25,7 +25,7 @@ import org.apache.griffin.measure.datasource.TimestampStorage
 /**
   * data source cache in json format
   */
-case class StreamingCacheJsonClient(sqlContext: SQLContext, param: Map[String, Any],
+case class StreamingCacheJsonClient(sqlContext: SparkSession, param: Map[String, Any],
                                     dsName: String, index: Int, timestampStorage: TimestampStorage
                               ) extends StreamingCacheClient {
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheOrcClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheOrcClient.scala
@@ -25,7 +25,7 @@ import org.apache.griffin.measure.datasource.TimestampStorage
 /**
   * data source cache in orc format
   */
-case class StreamingCacheOrcClient(sqlContext: SparkSession, param: Map[String, Any],
+case class StreamingCacheOrcClient(sparkSession: SparkSession, param: Map[String, Any],
                                    dsName: String, index: Int, timestampStorage: TimestampStorage
                              ) extends StreamingCacheClient {
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheOrcClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheOrcClient.scala
@@ -25,7 +25,7 @@ import org.apache.griffin.measure.datasource.TimestampStorage
 /**
   * data source cache in orc format
   */
-case class StreamingCacheOrcClient(sqlContext: SQLContext, param: Map[String, Any],
+case class StreamingCacheOrcClient(sqlContext: SparkSession, param: Map[String, Any],
                                    dsName: String, index: Int, timestampStorage: TimestampStorage
                              ) extends StreamingCacheClient {
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheParquetClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheParquetClient.scala
@@ -25,14 +25,14 @@ import org.apache.griffin.measure.datasource.TimestampStorage
 /**
   * data source cache in parquet format
   */
-case class StreamingCacheParquetClient(sqlContext: SparkSession,
+case class StreamingCacheParquetClient(sparkSession: SparkSession,
                                        param: Map[String, Any],
                                        dsName: String,
                                        index: Int,
                                        timestampStorage: TimestampStorage
                                  ) extends StreamingCacheClient {
 
-  sqlContext.sparkContext.hadoopConfiguration.set("parquet.enable.summary-metadata", "false")
+  sparkSession.sparkContext.hadoopConfiguration.set("parquet.enable.summary-metadata", "false")
 
   protected def writeDataFrame(dfw: DataFrameWriter[Row], path: String): Unit = {
     info(s"write path: ${path}")

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheParquetClient.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/cache/StreamingCacheParquetClient.scala
@@ -25,7 +25,7 @@ import org.apache.griffin.measure.datasource.TimestampStorage
 /**
   * data source cache in parquet format
   */
-case class StreamingCacheParquetClient(sqlContext: SQLContext,
+case class StreamingCacheParquetClient(sqlContext: SparkSession,
                                        param: Map[String, Any],
                                        dsName: String,
                                        index: Int,

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/TextDirBatchDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/TextDirBatchDataConnector.scala
@@ -98,7 +98,7 @@ case class TextDirBatchDataConnector(@transient sparkSession: SparkSession,
 
 //  def metaData(): Try[Iterable[(String, String)]] = {
 //    Try {
-//      val st = sqlContext.read.format("com.databricks.spark.avro").
+//      val st = sparkSession.read.format("com.databricks.spark.avro").
   //       load(concreteFileFullPath).schema
 //      st.fields.map(f => (f.name, f.dataType.typeName))
 //    }

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
@@ -23,7 +23,7 @@ import java.util.Date
 import scala.util.Try
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{SparkSession, SQLContext}
+import org.apache.spark.sql.SparkSession
 
 import org.apache.griffin.measure.configuration.dqdefinition._
 import org.apache.griffin.measure.configuration.enums._
@@ -43,7 +43,6 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
   val metricName = dqParam.getName
   val sinkParams = getSinkParams
 
-  var sqlContext: SQLContext = _
   var dqContext: DQContext = _
 
   def retryable: Boolean = false
@@ -57,10 +56,9 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
     val logLevel = getGriffinLogLevel()
     sparkSession.sparkContext.setLogLevel(sparkParam.getLogLevel)
     griffinLogger.setLevel(logLevel)
-    sqlContext = sparkSession.sqlContext
 
     // register udf
-    GriffinUDFAgent.register(sqlContext)
+    GriffinUDFAgent.register(sparkSession)
   }
 
   def run: Try[Boolean] = Try {

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.{Executors, ThreadPoolExecutor, TimeUnit}
 import scala.util.Try
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{SparkSession, SQLContext}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.streaming.{Milliseconds, StreamingContext}
 
 import org.apache.griffin.measure.Loggable
@@ -49,8 +49,6 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
   val metricName = dqParam.getName
   val sinkParams = getSinkParams
 
-  var sqlContext: SQLContext = _
-
   def retryable: Boolean = true
 
   def init: Try[_] = Try {
@@ -62,7 +60,6 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
     val logLevel = getGriffinLogLevel()
     sparkSession.sparkContext.setLogLevel(sparkParam.getLogLevel)
     griffinLogger.setLevel(logLevel)
-    sqlContext = sparkSession.sqlContext
 
     // clear checkpoint directory
     clearCpDir
@@ -72,7 +69,7 @@ case class StreamingDQApp(allParam: GriffinConfig) extends DQApp {
     OffsetCheckpointClient.init
 
     // register udf
-    GriffinUDFAgent.register(sqlContext)
+    GriffinUDFAgent.register(sparkSession)
   }
 
   def run: Try[Boolean] = Try {

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/udf/GriffinUDFs.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/udf/GriffinUDFs.scala
@@ -18,10 +18,10 @@ under the License.
 */
 package org.apache.griffin.measure.step.builder.udf
 
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 
 object GriffinUDFAgent {
-  def register(sqlContext: SQLContext): Unit = {
+  def register(sqlContext: SparkSession): Unit = {
     GriffinUDFs.register(sqlContext)
     GriffinUDAggFs.register(sqlContext)
   }
@@ -32,7 +32,7 @@ object GriffinUDFAgent {
   */
 object GriffinUDFs {
 
-  def register(sqlContext: SQLContext): Unit = {
+  def register(sqlContext: SparkSession): Unit = {
     sqlContext.udf.register("index_of", indexOf _)
     sqlContext.udf.register("matches", matches _)
     sqlContext.udf.register("reg_replace", regReplace _)
@@ -57,7 +57,7 @@ object GriffinUDFs {
   */
 object GriffinUDAggFs {
 
-  def register(sqlContext: SQLContext): Unit = {
+  def register(sqlContext: SparkSession): Unit = {
   }
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/udf/GriffinUDFs.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/udf/GriffinUDFs.scala
@@ -21,9 +21,9 @@ package org.apache.griffin.measure.step.builder.udf
 import org.apache.spark.sql.SparkSession
 
 object GriffinUDFAgent {
-  def register(sqlContext: SparkSession): Unit = {
-    GriffinUDFs.register(sqlContext)
-    GriffinUDAggFs.register(sqlContext)
+  def register(sparkSession: SparkSession): Unit = {
+    GriffinUDFs.register(sparkSession)
+    GriffinUDAggFs.register(sparkSession)
   }
 }
 
@@ -32,10 +32,10 @@ object GriffinUDFAgent {
   */
 object GriffinUDFs {
 
-  def register(sqlContext: SparkSession): Unit = {
-    sqlContext.udf.register("index_of", indexOf _)
-    sqlContext.udf.register("matches", matches _)
-    sqlContext.udf.register("reg_replace", regReplace _)
+  def register(sparkSession: SparkSession): Unit = {
+    sparkSession.udf.register("index_of", indexOf _)
+    sparkSession.udf.register("matches", matches _)
+    sparkSession.udf.register("reg_replace", regReplace _)
   }
 
   private def indexOf(arr: Seq[String], v: String) = {
@@ -57,7 +57,7 @@ object GriffinUDFs {
   */
 object GriffinUDAggFs {
 
-  def register(sqlContext: SparkSession): Unit = {
+  def register(sparkSession: SparkSession): Unit = {
   }
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOps.scala
@@ -46,7 +46,7 @@ object DataFrameOps {
     val _matchedFraction = "matchedFraction"
   }
 
-  def fromJson(sqlContext: SparkSession,
+  def fromJson(sparkSession: SparkSession,
                inputDfName: String,
                details: Map[String, Any]): DataFrame = {
     val _colName = "col.name"
@@ -54,15 +54,15 @@ object DataFrameOps {
 
     implicit val encoder = Encoders.STRING
 
-    val df: DataFrame = sqlContext.table(s"`${inputDfName}`")
+    val df: DataFrame = sparkSession.table(s"`${inputDfName}`")
     val rdd = colNameOpt match {
       case Some(colName: String) => df.map(r => r.getAs[String](colName))
       case _ => df.map(_.getAs[String](0))
     }
-    sqlContext.read.json(rdd) // slow process
+    sparkSession.read.json(rdd) // slow process
   }
 
-  def accuracy(sqlContext: SparkSession,
+  def accuracy(sparkSession: SparkSession,
                inputDfName: String,
                contextId: ContextId,
                details: Map[String, Any]): DataFrame = {
@@ -83,7 +83,7 @@ object DataFrameOps {
       }
     }
 
-    val df = sqlContext.table(s"`${inputDfName}`")
+    val df = sparkSession.table(s"`${inputDfName}`")
 
     val results = df.rdd.flatMap { row =>
       try {
@@ -117,16 +117,16 @@ object DataFrameOps {
       val ar = r.result.asInstanceOf[AccuracyMetric]
       Row(r.timeStamp, ar.miss, ar.total, ar.getMatch, ar.matchFraction, !ar.initial, ar.eventual)
     }.toArray
-    val rowRdd = sqlContext.sparkContext.parallelize(rows)
-    val retDf = sqlContext.createDataFrame(rowRdd, schema)
+    val rowRdd = sparkSession.sparkContext.parallelize(rows)
+    val retDf = sparkSession.createDataFrame(rowRdd, schema)
 
     retDf
   }
 
-  def clear(sqlContext: SparkSession, inputDfName: String, details: Map[String, Any]): DataFrame = {
-    val df = sqlContext.table(s"`${inputDfName}`")
-    val emptyRdd = sqlContext.sparkContext.emptyRDD[Row]
-    sqlContext.createDataFrame(emptyRdd, df.schema)
+  def clear(sparkSession: SparkSession, inputDfName: String, details: Map[String, Any]): DataFrame = {
+    val df = sparkSession.table(s"`${inputDfName}`")
+    val emptyRdd = sparkSession.sparkContext.emptyRDD[Row]
+    sparkSession.createDataFrame(emptyRdd, df.schema)
   }
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOps.scala
@@ -20,8 +20,9 @@ package org.apache.griffin.measure.step.transform
 
 import java.util.Date
 
-import org.apache.spark.sql.{Encoders, Row, SQLContext, _}
+import org.apache.spark.sql.{Encoders, Row, _}
 import org.apache.spark.sql.types._
+
 import org.apache.griffin.measure.context.ContextId
 import org.apache.griffin.measure.context.streaming.metric._
 import org.apache.griffin.measure.context.streaming.metric.CacheResults.CacheResult
@@ -45,7 +46,7 @@ object DataFrameOps {
     val _matchedFraction = "matchedFraction"
   }
 
-  def fromJson(sqlContext: SQLContext,
+  def fromJson(sqlContext: SparkSession,
                inputDfName: String,
                details: Map[String, Any]): DataFrame = {
     val _colName = "col.name"
@@ -61,7 +62,7 @@ object DataFrameOps {
     sqlContext.read.json(rdd) // slow process
   }
 
-  def accuracy(sqlContext: SQLContext,
+  def accuracy(sqlContext: SparkSession,
                inputDfName: String,
                contextId: ContextId,
                details: Map[String, Any]): DataFrame = {
@@ -122,7 +123,7 @@ object DataFrameOps {
     retDf
   }
 
-  def clear(sqlContext: SQLContext, inputDfName: String, details: Map[String, Any]): DataFrame = {
+  def clear(sqlContext: SparkSession, inputDfName: String, details: Map[String, Any]): DataFrame = {
     val df = sqlContext.table(s"`${inputDfName}`")
     val emptyRdd = sqlContext.sparkContext.emptyRDD[Row]
     sqlContext.createDataFrame(emptyRdd, df.schema)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
@@ -33,7 +33,7 @@ case class DataFrameOpsTransformStep[T <: WriteStep](name: String,
                                     ) extends TransformStep {
 
   def doExecute(context: DQContext): Boolean = {
-    val sqlContext = context.sqlContext
+    val sqlContext = context.sparkSession
     try {
       val df = rule match {
         case DataFrameOps._fromJson => DataFrameOps.fromJson(sqlContext, inputDfName, details)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/DataFrameOpsTransformStep.scala
@@ -33,14 +33,14 @@ case class DataFrameOpsTransformStep[T <: WriteStep](name: String,
                                     ) extends TransformStep {
 
   def doExecute(context: DQContext): Boolean = {
-    val sqlContext = context.sparkSession
+    val sparkSession = context.sparkSession
     try {
       val df = rule match {
-        case DataFrameOps._fromJson => DataFrameOps.fromJson(sqlContext, inputDfName, details)
+        case DataFrameOps._fromJson => DataFrameOps.fromJson(sparkSession, inputDfName, details)
         case DataFrameOps._accuracy =>
-          DataFrameOps.accuracy(sqlContext, inputDfName, context.contextId, details)
+          DataFrameOps.accuracy(sparkSession, inputDfName, context.contextId, details)
 
-        case DataFrameOps._clear => DataFrameOps.clear(sqlContext, inputDfName, details)
+        case DataFrameOps._clear => DataFrameOps.clear(sparkSession, inputDfName, details)
         case _ => throw new Exception(s"df opr [ ${rule} ] not supported")
       }
       if (cache) context.dataFrameCache.cacheDataFrame(name, df)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
@@ -31,7 +31,7 @@ case class SparkSqlTransformStep[T <: WriteStep](name: String,
                                                  cache: Boolean = false
                                                 ) extends TransformStep {
   def doExecute(context: DQContext): Boolean = {
-    val sqlContext = context.sqlContext
+    val sqlContext = context.sparkSession
     try {
       val df = sqlContext.sql(rule)
       if (cache) context.dataFrameCache.cacheDataFrame(name, df)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/transform/SparkSqlTransformStep.scala
@@ -31,9 +31,9 @@ case class SparkSqlTransformStep[T <: WriteStep](name: String,
                                                  cache: Boolean = false
                                                 ) extends TransformStep {
   def doExecute(context: DQContext): Boolean = {
-    val sqlContext = context.sparkSession
+    val sparkSession = context.sparkSession
     try {
-      val df = sqlContext.sql(rule)
+      val df = sparkSession.sql(rule)
       if (cache) context.dataFrameCache.cacheDataFrame(name, df)
       context.runTimeTableRegister.registerTable(name, df)
       writeStepOpt match {

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/DataSourceUpdateWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/DataSourceUpdateWriteStep.scala
@@ -47,7 +47,7 @@ case class DataSourceUpdateWriteStep(dsName: String,
 
   private def getDataFrame(context: DQContext, name: String): Option[DataFrame] = {
     try {
-      val df = context.sqlContext.table(s"`${name}`")
+      val df = context.sparkSession.table(s"`${name}`")
       Some(df)
     } catch {
       case e: Throwable =>

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
@@ -75,7 +75,7 @@ case class MetricWriteStep(name: String,
 
   private def getMetricMaps(context: DQContext): Seq[Map[String, Any]] = {
     try {
-      val pdf = context.sqlContext.table(s"`${inputName}`")
+      val pdf = context.sparkSession.table(s"`${inputName}`")
       val records = pdf.toJSON.collect()
       if (records.size > 0) {
         records.flatMap { rec =>

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/RecordWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/RecordWriteStep.scala
@@ -76,7 +76,7 @@ case class RecordWriteStep(name: String,
 
   private def getDataFrame(context: DQContext, name: String): Option[DataFrame] = {
     try {
-      val df = context.sqlContext.table(s"`${name}`")
+      val df = context.sparkSession.table(s"`${name}`")
       Some(df)
     } catch {
       case e: Throwable =>

--- a/measure/src/test/scala/org/apache/griffin/measure/job/BatchDQAppTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/job/BatchDQAppTest.scala
@@ -47,7 +47,6 @@ class BatchDQAppTest extends DQAppTest {
       val logLevel = getGriffinLogLevel()
       sc.setLogLevel(sparkParam.getLogLevel)
       griffinLogger.setLevel(logLevel)
-      val sqlContext = spark.sqlContext
 
       // register udf
       GriffinUDFAgent.register(spark)

--- a/measure/src/test/scala/org/apache/griffin/measure/job/BatchDQAppTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/job/BatchDQAppTest.scala
@@ -50,7 +50,7 @@ class BatchDQAppTest extends DQAppTest {
       val sqlContext = spark.sqlContext
 
       // register udf
-      GriffinUDFAgent.register(sqlContext)
+      GriffinUDFAgent.register(spark)
     }
   }
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**

As SparkSession is a direct replacement for SparkContext, SQLContext and HiveContext, there is no need to pass/ instantiate them. If any of the oder contexts are needed, they can be derived from SparkSession.

This issue aims to eliminate dependency on older Contexts in favour of SparkSession.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Griffin test suite.