### PR TITLE
Enum based configs

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/Application.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Application.scala
@@ -20,10 +20,10 @@ package org.apache.griffin.measure
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
-
 import org.apache.griffin.measure.configuration.dqdefinition.{DQConfig, EnvConfig, GriffinConfig, Param}
 import org.apache.griffin.measure.configuration.dqdefinition.reader.ParamReaderFactory
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.ProcessType
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.launch.DQApp
 import org.apache.griffin.measure.launch.batch.BatchDQApp
 import org.apache.griffin.measure.launch.streaming.StreamingDQApp
@@ -65,8 +65,8 @@ object Application extends Loggable {
     // choose process
     val procType = ProcessType.withNameWithDefault(allParam.getDqConfig.getProcType)
     val dqApp: DQApp = procType match {
-      case ProcessType.BatchProcessType => BatchDQApp(allParam)
-      case ProcessType.StreamingProcessType => StreamingDQApp(allParam)
+      case BatchProcessType => BatchDQApp(allParam)
+      case StreamingProcessType => StreamingDQApp(allParam)
       case _ =>
         error(s"${procType} is unsupported process type!")
         sys.exit(-4)

--- a/measure/src/main/scala/org/apache/griffin/measure/Application.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Application.scala
@@ -19,6 +19,7 @@ package org.apache.griffin.measure
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
+
 import org.apache.griffin.measure.configuration.dqdefinition.{DQConfig, EnvConfig, GriffinConfig, Param}
 import org.apache.griffin.measure.configuration.dqdefinition.reader.ParamReaderFactory
 import org.apache.griffin.measure.configuration.enums.ProcessType

--- a/measure/src/main/scala/org/apache/griffin/measure/Application.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/Application.scala
@@ -63,10 +63,10 @@ object Application extends Loggable {
     val allParam: GriffinConfig = GriffinConfig(envParam, dqParam)
 
     // choose process
-    val procType = ProcessType(allParam.getDqConfig.getProcType)
+    val procType = ProcessType.withNameWithDefault(allParam.getDqConfig.getProcType)
     val dqApp: DQApp = procType match {
-      case BatchProcessType => BatchDQApp(allParam)
-      case StreamingProcessType => StreamingDQApp(allParam)
+      case ProcessType.BatchProcessType => BatchDQApp(allParam)
+      case ProcessType.StreamingProcessType => StreamingDQApp(allParam)
       case _ =>
         error(s"${procType} is unsupported process type!")
         sys.exit(-4)

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
@@ -20,11 +20,12 @@ package org.apache.griffin.measure.configuration.dqdefinition
 import com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import org.apache.commons.lang.StringUtils
+
+import org.apache.griffin.measure.configuration.enums.{DqType, DslType, FlattenType, OutputType, SinkType}
 import org.apache.griffin.measure.configuration.enums.DqType._
 import org.apache.griffin.measure.configuration.enums.DslType.{DslType, GriffinDsl}
-import org.apache.griffin.measure.configuration.enums.FlattenType.{FlattenType,DefaultFlattenType}
-import org.apache.griffin.measure.configuration.enums.OutputType.{OutputType,UnknownOutputType}
-import org.apache.griffin.measure.configuration.enums.{DqType, DslType, FlattenType, OutputType, SinkType}
+import org.apache.griffin.measure.configuration.enums.FlattenType.{DefaultFlattenType, FlattenType}
+import org.apache.griffin.measure.configuration.enums.OutputType.{OutputType, UnknownOutputType}
 import org.apache.griffin.measure.configuration.enums.SinkType.SinkType
 
 /**
@@ -208,9 +209,15 @@ case class RuleOutputParam( @JsonProperty("type") private val outputType: String
                             @JsonProperty("name") private val name: String,
                             @JsonProperty("flatten") private val flatten: String
                           ) extends Param {
-  def getOutputType: OutputType = if (outputType != null) OutputType.withNameWithDefault(outputType) else UnknownOutputType
+  def getOutputType: OutputType = {
+    if (outputType != null) OutputType.withNameWithDefault(outputType)
+    else UnknownOutputType
+  }
   def getNameOpt: Option[String] = if (StringUtils.isNotBlank(name)) Some(name) else None
-  def getFlatten: FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType.withNameWithDefault(flatten) else DefaultFlattenType
+  def getFlatten: FlattenType = {
+    if (StringUtils.isNotBlank(flatten)) FlattenType.withNameWithDefault(flatten)
+    else DefaultFlattenType
+  }
 
   def validate(): Unit = {}
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
@@ -21,8 +21,12 @@ package org.apache.griffin.measure.configuration.dqdefinition
 import com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import org.apache.commons.lang.StringUtils
-
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.DqType._
+import org.apache.griffin.measure.configuration.enums.DslType.{DslType, GriffinDsl}
+import org.apache.griffin.measure.configuration.enums.FlattenType.{FlattenType,DefaultFlattenType}
+import org.apache.griffin.measure.configuration.enums.OutputType.{OutputType,UnknownOutputType}
+import org.apache.griffin.measure.configuration.enums.{DqType, DslType, FlattenType, OutputType, SinkType}
+import org.apache.griffin.measure.configuration.enums.SinkType.SinkType
 
 /**
   * dq param
@@ -53,7 +57,7 @@ case class DQConfig(@JsonProperty("name") private val name: String,
     }._1
   }
   def getEvaluateRule: EvaluateRuleParam = evaluateRule
-  def getValidSinkTypes: Seq[SinkType.SinkType] = SinkType.validSinkTypes(if (sinks != null) sinks else Nil)
+  def getValidSinkTypes: Seq[SinkType] = SinkType.validSinkTypes(if (sinks != null) sinks else Nil)
 
   def validate(): Unit = {
     assert(StringUtils.isNotBlank(name), "dq config name should not be blank")
@@ -154,8 +158,8 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
                      @JsonProperty("out") private val outputs: List[RuleOutputParam] = null,
                      @JsonProperty("error.confs") private val errorConfs: List[RuleErrorConfParam] = null
                     ) extends Param {
-  def getDslType: DslType.DslType = if (dslType != null) DslType.withNameWithDefault(dslType) else DslType.GriffinDsl
-  def getDqType: DqType.DqType = if (dqType != null) DqType.withNameWithDefault(dqType) else DqType.Unknown
+  def getDslType: DslType = if (dslType != null) DslType.withNameWithDefault(dslType) else GriffinDsl
+  def getDqType: DqType = if (dqType != null) DqType.withNameWithDefault(dqType) else Unknown
   def getCache: Boolean = if (cache) cache else false
 
   def getInDfName(defName: String = ""): String = if (inDfName != null) inDfName else defName
@@ -164,7 +168,7 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
   def getDetails: Map[String, Any] = if (details != null) details else Map[String, Any]()
 
   def getOutputs: Seq[RuleOutputParam] = if (outputs != null) outputs else Nil
-  def getOutputOpt(tp: OutputType.OutputType): Option[RuleOutputParam] = getOutputs.filter(_.getOutputType == tp).headOption
+  def getOutputOpt(tp: OutputType): Option[RuleOutputParam] = getOutputs.filter(_.getOutputType == tp).headOption
 
   def getErrorConfs: Seq[RuleErrorConfParam] = if (errorConfs != null) errorConfs else Nil
 
@@ -186,7 +190,7 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
   }
 
   def validate(): Unit = {
-    assert(!(getDslType.equals(DslType.GriffinDsl) && getDqType.equals(DqType.Unknown)),
+    assert(!(getDslType.equals(GriffinDsl) && getDqType.equals(Unknown)),
       "unknown dq type for griffin dsl")
 
     getOutputs.foreach(_.validate)
@@ -205,9 +209,9 @@ case class RuleOutputParam( @JsonProperty("type") private val outputType: String
                             @JsonProperty("name") private val name: String,
                             @JsonProperty("flatten") private val flatten: String
                           ) extends Param {
-  def getOutputType: OutputType.OutputType = if (outputType != null) OutputType.withNameWithDefault(outputType) else OutputType.UnknownOutputType
+  def getOutputType: OutputType = if (outputType != null) OutputType.withNameWithDefault(outputType) else UnknownOutputType
   def getNameOpt: Option[String] = if (StringUtils.isNotBlank(name)) Some(name) else None
-  def getFlatten: FlattenType.FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType.withNameWithDefault(flatten) else FlattenType.DefaultFlattenType
+  def getFlatten: FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType.withNameWithDefault(flatten) else DefaultFlattenType
 
   def validate(): Unit = {}
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
@@ -53,7 +53,7 @@ case class DQConfig(@JsonProperty("name") private val name: String,
     }._1
   }
   def getEvaluateRule: EvaluateRuleParam = evaluateRule
-  def getValidSinkTypes: Seq[SinkType] = SinkType.validSinkTypes(if (sinks != null) sinks else Nil)
+  def getValidSinkTypes: Seq[SinkType.SinkType] = SinkType.validSinkTypes(if (sinks != null) sinks else Nil)
 
   def validate(): Unit = {
     assert(StringUtils.isNotBlank(name), "dq config name should not be blank")
@@ -154,8 +154,8 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
                      @JsonProperty("out") private val outputs: List[RuleOutputParam] = null,
                      @JsonProperty("error.confs") private val errorConfs: List[RuleErrorConfParam] = null
                     ) extends Param {
-  def getDslType: DslType = if (dslType != null) DslType(dslType) else DslType("")
-  def getDqType: DqType = if (dqType != null) DqType(dqType) else DqType("")
+  def getDslType: DslType.DslType = if (dslType != null) DslType.withNameWithDslType(dslType) else DslType.Unknown
+  def getDqType: DqType.DqType = if (dqType != null) DqType.withNameWithDefault(dqType) else DqType.Unknown
   def getCache: Boolean = if (cache) cache else false
 
   def getInDfName(defName: String = ""): String = if (inDfName != null) inDfName else defName
@@ -164,7 +164,7 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
   def getDetails: Map[String, Any] = if (details != null) details else Map[String, Any]()
 
   def getOutputs: Seq[RuleOutputParam] = if (outputs != null) outputs else Nil
-  def getOutputOpt(tp: OutputType): Option[RuleOutputParam] = getOutputs.filter(_.getOutputType == tp).headOption
+  def getOutputOpt(tp: OutputType.OutputType): Option[RuleOutputParam] = getOutputs.filter(_.getOutputType == tp).headOption
 
   def getErrorConfs: Seq[RuleErrorConfParam] = if (errorConfs != null) errorConfs else Nil
 
@@ -186,7 +186,7 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
   }
 
   def validate(): Unit = {
-    assert(!(getDslType.equals(GriffinDslType) && getDqType.equals(UnknownType)),
+    assert(!(getDslType.equals(DslType.GriffinDsl) && getDqType.equals(DqType.Unknown)),
       "unknown dq type for griffin dsl")
 
     getOutputs.foreach(_.validate)
@@ -205,9 +205,9 @@ case class RuleOutputParam( @JsonProperty("type") private val outputType: String
                             @JsonProperty("name") private val name: String,
                             @JsonProperty("flatten") private val flatten: String
                           ) extends Param {
-  def getOutputType: OutputType = if (outputType != null) OutputType(outputType) else OutputType("")
+  def getOutputType: OutputType.OutputType = if (outputType != null) OutputType.withNameOutputType(outputType) else OutputType.UnknownOutputType
   def getNameOpt: Option[String] = if (StringUtils.isNotBlank(name)) Some(name) else None
-  def getFlatten: FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType(flatten) else FlattenType("")
+  def getFlatten: FlattenType.FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType.withNameFlattenType(flatten) else FlattenType.DefaultFlattenType
 
   def validate(): Unit = {}
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
@@ -154,7 +154,7 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
                      @JsonProperty("out") private val outputs: List[RuleOutputParam] = null,
                      @JsonProperty("error.confs") private val errorConfs: List[RuleErrorConfParam] = null
                     ) extends Param {
-  def getDslType: DslType.DslType = if (dslType != null) DslType.withNameWithDslType(dslType) else DslType.Unknown
+  def getDslType: DslType.DslType = if (dslType != null) DslType.withNameWithDefault(dslType) else DslType.Unknown
   def getDqType: DqType.DqType = if (dqType != null) DqType.withNameWithDefault(dqType) else DqType.Unknown
   def getCache: Boolean = if (cache) cache else false
 

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/DQConfig.scala
@@ -154,7 +154,7 @@ case class RuleParam(@JsonProperty("dsl.type") private val dslType: String,
                      @JsonProperty("out") private val outputs: List[RuleOutputParam] = null,
                      @JsonProperty("error.confs") private val errorConfs: List[RuleErrorConfParam] = null
                     ) extends Param {
-  def getDslType: DslType.DslType = if (dslType != null) DslType.withNameWithDefault(dslType) else DslType.Unknown
+  def getDslType: DslType.DslType = if (dslType != null) DslType.withNameWithDefault(dslType) else DslType.GriffinDsl
   def getDqType: DqType.DqType = if (dqType != null) DqType.withNameWithDefault(dqType) else DqType.Unknown
   def getCache: Boolean = if (cache) cache else false
 
@@ -205,9 +205,9 @@ case class RuleOutputParam( @JsonProperty("type") private val outputType: String
                             @JsonProperty("name") private val name: String,
                             @JsonProperty("flatten") private val flatten: String
                           ) extends Param {
-  def getOutputType: OutputType.OutputType = if (outputType != null) OutputType.withNameOutputType(outputType) else OutputType.UnknownOutputType
+  def getOutputType: OutputType.OutputType = if (outputType != null) OutputType.withNameWithDefault(outputType) else OutputType.UnknownOutputType
   def getNameOpt: Option[String] = if (StringUtils.isNotBlank(name)) Some(name) else None
-  def getFlatten: FlattenType.FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType.withNameFlattenType(flatten) else FlattenType.DefaultFlattenType
+  def getFlatten: FlattenType.FlattenType = if (StringUtils.isNotBlank(flatten)) FlattenType.withNameWithDefault(flatten) else FlattenType.DefaultFlattenType
 
   def validate(): Unit = {}
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/EnvConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/EnvConfig.scala
@@ -21,8 +21,8 @@ package org.apache.griffin.measure.configuration.dqdefinition
 import com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import org.apache.commons.lang.StringUtils
-
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.SinkType
+import org.apache.griffin.measure.configuration.enums.SinkType.SinkType
 
 /**
   * environment param
@@ -87,7 +87,7 @@ case class SparkParam( @JsonProperty("log.level") private val logLevel: String,
 case class SinkParam(@JsonProperty("type") private val sinkType: String,
                      @JsonProperty("config") private val config: Map[String, Any]
                     ) extends Param {
-  def getType: SinkType.SinkType = SinkType.withNameWithDefault(sinkType)
+  def getType: SinkType = SinkType.withNameWithDefault(sinkType)
   def getConfig: Map[String, Any] = if (config != null) config else Map[String, Any]()
 
   def validate(): Unit = {

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/EnvConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/EnvConfig.scala
@@ -87,7 +87,7 @@ case class SparkParam( @JsonProperty("log.level") private val logLevel: String,
 case class SinkParam(@JsonProperty("type") private val sinkType: String,
                      @JsonProperty("config") private val config: Map[String, Any]
                     ) extends Param {
-  def getType: SinkType = SinkType(sinkType)
+  def getType: SinkType.SinkType = SinkType.withNameWithDefault(sinkType)
   def getConfig: Map[String, Any] = if (config != null) config else Map[String, Any]()
 
   def validate(): Unit = {

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/EnvConfig.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/dqdefinition/EnvConfig.scala
@@ -20,6 +20,7 @@ package org.apache.griffin.measure.configuration.dqdefinition
 import com.fasterxml.jackson.annotation.{JsonInclude, JsonProperty}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import org.apache.commons.lang.StringUtils
+
 import org.apache.griffin.measure.configuration.enums.SinkType
 import org.apache.griffin.measure.configuration.enums.SinkType.SinkType
 

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
@@ -39,7 +39,8 @@ import org.apache.griffin.measure.configuration.enums
   *                             comparing with uniqueness, distinctness is more meaningful</li>
   * <li>{@link #Timeliness} - The latency of data source with timestamp information
   *                           e.g.: (receive_time - send_time)
-  *                           timeliness can get the statistic metric of latency, like average, max, min, percentile-value,
+  *                           timeliness can get the statistic metric of latency, like average, max, min,
+  *                            percentile-value,
   *                           even more, it can record the items with latency above threshold you configured</li>
   * <li>{@link #Completeness} - The completeness of data source
   *                             the columns you measure is incomplete if it is null</li>
@@ -55,7 +56,7 @@ object DqType extends GriffinEnum {
     val dqType = super.withNameWithDefault(name)
     dqType match {
       case Uniqueness | Duplicate => Uniqueness
-      case _                      => dqType
+      case _ => dqType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
@@ -15,51 +15,48 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-*/
+ */
 package org.apache.griffin.measure.configuration.enums
 
 import org.apache.griffin.measure.configuration.enums
 
-import scala.util.matching.Regex
-
 /**
- * effective when dsl type is "griffin-dsl",
- * indicates the dq type of griffin pre-defined measurements
- * <li>{@link #Accuracy} - The match percentage of items between source and target
- *                         count(source items matched with the ones from target) / count(source)
- *                         e.g.: source [1, 2, 3, 4, 5], target: [1, 2, 3, 4]
- *                         metric will be: { "total": 5, "miss": 1, "matched": 4 } accuracy is 80%.</li>
- * <li>{@link #Profiling} - The statistic data of data source
- *                          e.g.: max, min, average, group by count, ...</li>
- * <li>{@link #Uniqueness} - The uniqueness of data source comparing with itself
- *                           count(unique items in source) / count(source)
- *                           e.g.: [1, 2, 3, 3] -> { "unique": 2, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
- *                           uniqueness indicates the items without any replica of data</li>
- * <li>{@link #Distinctness} - The distinctness of data source comparing with itself
- *                             count(distinct items in source) / count(source)
- *                             e.g.: [1, 2, 3, 3] -> { "dist": 3, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
- *                             distinctness indicates the valid information of data
- *                             comparing with uniqueness, distinctness is more meaningful</li>
- * <li>{@link #Timeliness} - The latency of data source with timestamp information
- *                           e.g.: (receive_time - send_time)
- *                           timeliness can get the statistic metric of latency, like average, max, min, percentile-value,
- *                           even more, it can record the items with latency above threshold you configured</li>
- * <li>{@link #Completeness} - The completeness of data source
- *                             the columns you measure is incomplete if it is null</li>
- */
+  * effective when dsl type is "griffin-dsl",
+  * indicates the dq type of griffin pre-defined measurements
+  * <li>{@link #Accuracy} - The match percentage of items between source and target
+  *                         count(source items matched with the ones from target) / count(source)
+  *                         e.g.: source [1, 2, 3, 4, 5], target: [1, 2, 3, 4]
+  *                         metric will be: { "total": 5, "miss": 1, "matched": 4 } accuracy is 80%.</li>
+  * <li>{@link #Profiling} - The statistic data of data source
+  *                          e.g.: max, min, average, group by count, ...</li>
+  * <li>{@link #Uniqueness} - The uniqueness of data source comparing with itself
+  *                           count(unique items in source) / count(source)
+  *                           e.g.: [1, 2, 3, 3] -> { "unique": 2, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
+  *                           uniqueness indicates the items without any replica of data</li>
+  * <li>{@link #Distinctness} - The distinctness of data source comparing with itself
+  *                             count(distinct items in source) / count(source)
+  *                             e.g.: [1, 2, 3, 3] -> { "dist": 3, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
+  *                             distinctness indicates the valid information of data
+  *                             comparing with uniqueness, distinctness is more meaningful</li>
+  * <li>{@link #Timeliness} - The latency of data source with timestamp information
+  *                           e.g.: (receive_time - send_time)
+  *                           timeliness can get the statistic metric of latency, like average, max, min, percentile-value,
+  *                           even more, it can record the items with latency above threshold you configured</li>
+  * <li>{@link #Completeness} - The completeness of data source
+  *                             the columns you measure is incomplete if it is null</li>
+  */
 object DqType extends GriffinEnum {
 
   type DqType = Value
 
-  val Accuracy, Profiling, Uniqueness, Duplicate ,Distinct, Timeliness, Completeness = Value
+  val Accuracy, Profiling, Uniqueness, Duplicate, Distinct, Timeliness,
+  Completeness = Value
 
-  override def withNameWithDefault(
-    name: String
-  ): enums.DqType.Value = {
-      val dqType = super.withNameWithDefault(name)
-      dqType match {
-        case Uniqueness | Duplicate => Uniqueness
-        case _                      => dqType
-      }
+  override def withNameWithDefault(name: String): enums.DqType.Value = {
+    val dqType = super.withNameWithDefault(name)
+    dqType match {
+      case Uniqueness | Duplicate => Uniqueness
+      case _                      => dqType
     }
+  }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
@@ -18,6 +18,8 @@ under the License.
 */
 package org.apache.griffin.measure.configuration.enums
 
+import org.apache.griffin.measure.configuration.enums
+
 import scala.util.matching.Regex
 
 /**
@@ -49,7 +51,16 @@ object DqType extends GriffinEnum {
 
   type DqType = Value
 
-  val Accuracy, Profiling, Uniqueness, Distinct, Timeliness, Completeness,
+  val Accuracy, Profiling, Uniqueness, Duplicate ,Distinct, Timeliness, Completeness,
   Unknown = Value
 
+  override def withNameWithDefault(
+    name: String
+  ): enums.DqType.Value = {
+      val dqType = super.withNameWithDefault(name)
+      dqType match {
+        case Uniqueness | Duplicate => Uniqueness
+        case _                      => dqType
+      }
+    }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
@@ -51,8 +51,7 @@ object DqType extends GriffinEnum {
 
   type DqType = Value
 
-  val Accuracy, Profiling, Uniqueness, Duplicate ,Distinct, Timeliness, Completeness,
-  Unknown = Value
+  val Accuracy, Profiling, Uniqueness, Duplicate ,Distinct, Timeliness, Completeness = Value
 
   override def withNameWithDefault(
     name: String

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DqType.scala
@@ -21,98 +21,35 @@ package org.apache.griffin.measure.configuration.enums
 import scala.util.matching.Regex
 
 /**
-  * effective when dsl type is "griffin-dsl",
-  * indicates the dq type of griffin pre-defined measurements
-  */
-sealed trait DqType {
-  val idPattern: Regex
-  val desc: String
-}
+ * effective when dsl type is "griffin-dsl",
+ * indicates the dq type of griffin pre-defined measurements
+ * <li>{@link #Accuracy} - The match percentage of items between source and target
+ *                         count(source items matched with the ones from target) / count(source)
+ *                         e.g.: source [1, 2, 3, 4, 5], target: [1, 2, 3, 4]
+ *                         metric will be: { "total": 5, "miss": 1, "matched": 4 } accuracy is 80%.</li>
+ * <li>{@link #Profiling} - The statistic data of data source
+ *                          e.g.: max, min, average, group by count, ...</li>
+ * <li>{@link #Uniqueness} - The uniqueness of data source comparing with itself
+ *                           count(unique items in source) / count(source)
+ *                           e.g.: [1, 2, 3, 3] -> { "unique": 2, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
+ *                           uniqueness indicates the items without any replica of data</li>
+ * <li>{@link #Distinctness} - The distinctness of data source comparing with itself
+ *                             count(distinct items in source) / count(source)
+ *                             e.g.: [1, 2, 3, 3] -> { "dist": 3, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
+ *                             distinctness indicates the valid information of data
+ *                             comparing with uniqueness, distinctness is more meaningful</li>
+ * <li>{@link #Timeliness} - The latency of data source with timestamp information
+ *                           e.g.: (receive_time - send_time)
+ *                           timeliness can get the statistic metric of latency, like average, max, min, percentile-value,
+ *                           even more, it can record the items with latency above threshold you configured</li>
+ * <li>{@link #Completeness} - The completeness of data source
+ *                             the columns you measure is incomplete if it is null</li>
+ */
+object DqType extends GriffinEnum {
 
-object DqType {
-  private val dqTypes: List[DqType] = List(
-    AccuracyType,
-    ProfilingType,
-    UniquenessType,
-    DistinctnessType,
-    TimelinessType,
-    CompletenessType,
-    UnknownType
-  )
-  def apply(ptn: String): DqType = {
-    dqTypes.find(dqType => ptn match {
-      case dqType.idPattern() => true
-      case _ => false
-    }).getOrElse(UnknownType)
-  }
-  def unapply(pt: DqType): Option[String] = Some(pt.desc)
-}
+  type DqType = Value
 
-/**
-  * accuracy: the match percentage of items between source and target
-  * count(source items matched with the ones from target) / count(source)
-  * e.g.: source [1, 2, 3, 4, 5], target: [1, 2, 3, 4]
-  *       metric will be: { "total": 5, "miss": 1, "matched": 4 }
-  *       accuracy is 80%.
-  */
- case object AccuracyType extends DqType {
-  val idPattern = "^(?i)accuracy$".r
-  val desc = "accuracy"
-}
+  val Accuracy, Profiling, Uniqueness, Distinct, Timeliness, Completeness,
+  Unknown = Value
 
-/**
-  * profiling: the statistic data of data source
-  * e.g.: max, min, average, group by count, ...
-  */
- case object ProfilingType extends DqType {
-  val idPattern = "^(?i)profiling$".r
-  val desc = "profiling"
-}
-
-/**
-  * uniqueness: the uniqueness of data source comparing with itself
-  * count(unique items in source) / count(source)
-  * e.g.: [1, 2, 3, 3] -> { "unique": 2, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
-  * uniqueness indicates the items without any replica of data
-  */
- case object UniquenessType extends DqType {
-  val idPattern = "^(?i)uniqueness|duplicate$".r
-  val desc = "uniqueness"
-}
-
-/**
-  * distinctness: the distinctness of data source comparing with itself
-  * count(distinct items in source) / count(source)
-  * e.g.: [1, 2, 3, 3] -> { "dist": 3, "total": 4, "dup-arr": [ "dup": 1, "num": 1 ] }
-  * distinctness indicates the valid information of data
-  * comparing with uniqueness, distinctness is more meaningful
-  */
- case object DistinctnessType extends DqType {
-  val idPattern = "^(?i)distinct$".r
-  val desc = "distinct"
-}
-
-/**
-  * timeliness: the latency of data source with timestamp information
-  * e.g.: (receive_time - send_time)
-  * timeliness can get the statistic metric of latency, like average, max, min, percentile-value,
-  * even more, it can record the items with latency above threshold you configured
-  */
- case object TimelinessType extends DqType {
-  val idPattern = "^(?i)timeliness$".r
-  val desc = "timeliness"
-}
-
-/**
-  * completeness: the completeness of data source
-  * the columns you measure is incomplete if it is null
-  */
- case object CompletenessType extends DqType {
-  val idPattern = "^(?i)completeness$".r
-  val desc = "completeness"
-}
-
- case object UnknownType extends DqType {
-  val idPattern = "".r
-  val desc = "unknown"
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
@@ -28,7 +28,7 @@ import org.apache.griffin.measure.configuration.enums
 object DslType extends GriffinEnum {
   type DslType = Value
 
-  val SparkSql, DfOps, DfOpr, DfOperations, GriffinDsl = Value
+  val SparkSql, DfOps, DfOpr, DfOperations, GriffinDsl, DataFrameOpsType = Value
 
   /**
     *
@@ -43,7 +43,7 @@ object DslType extends GriffinEnum {
   override def withNameWithDefault(name: String): enums.DslType.Value = {
     val dslType = withNameWithDslType(name)
     dslType match {
-      case DfOps | DfOpr | DfOperations => DfOperations
+      case DfOps | DfOpr | DfOperations => DataFrameOpsType
       case _                            => dslType
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
@@ -16,6 +16,7 @@
  */
 
 package org.apache.griffin.measure.configuration.enums
+
 import org.apache.griffin.measure.configuration.enums
 
 /**
@@ -43,7 +44,7 @@ object DslType extends GriffinEnum {
     val dslType = withNameWithDslType(name)
     dslType match {
       case DfOps | DfOpr | DfOperations => DataFrameOpsType
-      case _                            => dslType
+      case _ => dslType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
@@ -18,47 +18,25 @@ under the License.
 */
 package org.apache.griffin.measure.configuration.enums
 
-import scala.util.matching.Regex
-
 /**
-  * dsl type indicates the language type of rule param
-  */
-sealed trait DslType {
-  val idPattern: Regex
-  val desc: String
-}
+ * dsl type indicates the language type of rule param
+ * <li>{@link #SparkSql} - spark-sql: rule defined in "SPARK-SQL" directly</li>
+ * <li>{@link #DfOps} - df-ops|df-opr|: data frame operations rule, support some pre-defined data frame ops()</li>
+ * <li>{@link #GriffinDsl} - griffin dsl rule, to define dq measurements easier</li>
+ */
+object DslType extends GriffinEnum {
+  type DslType = Value
 
-object DslType {
-  private val dslTypes: List[DslType] = List(SparkSqlType, GriffinDslType, DataFrameOpsType)
-  def apply(ptn: String): DslType = {
-    dslTypes.find(tp => ptn match {
-      case tp.idPattern() => true
-      case _ => false
-    }).getOrElse(GriffinDslType)
-  }
-  def unapply(pt: DslType): Option[String] = Some(pt.desc)
-}
+  val SparkSql, DfOps, DfOpr, DfOperations, GriffinDsl, Unknown = Value
+  //todo - removed redudant variables
+  /**
+   *
+   * @param name Dsltype from config file
+   * @return Enum value corresponding to string
+   */
+  def withNameWithDslType(name: String): Value =
+    values
+      .find(_.toString.toLowerCase == name.replace("-", "").toLowerCase())
+      .getOrElse(Value)
 
-/**
-  * spark-sql: rule defined in "SPARK-SQL" directly
-  */
- case object SparkSqlType extends DslType {
-  val idPattern = "^(?i)spark-?sql$".r
-  val desc = "spark-sql"
-}
-
-/**
-  * df-ops: data frame operations rule, support some pre-defined data frame ops
-  */
- case object DataFrameOpsType extends DslType {
-  val idPattern = "^(?i)df-?(?:ops|opr|operations)$".r
-  val desc = "df-ops"
-}
-
-/**
-  * griffin-dsl: griffin dsl rule, to define dq measurements easier
-  */
- case object GriffinDslType extends DslType {
-  val idPattern = "^(?i)griffin-?dsl$".r
-  val desc = "griffin-dsl"
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
@@ -15,28 +15,36 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-*/
+ */
 package org.apache.griffin.measure.configuration.enums
+import org.apache.griffin.measure.configuration.enums
 
 /**
- * dsl type indicates the language type of rule param
- * <li>{@link #SparkSql} - spark-sql: rule defined in "SPARK-SQL" directly</li>
- * <li>{@link #DfOps} - df-ops|df-opr|: data frame operations rule, support some pre-defined data frame ops()</li>
- * <li>{@link #GriffinDsl} - griffin dsl rule, to define dq measurements easier</li>
- */
+  * dsl type indicates the language type of rule param
+  * <li>{@link #SparkSql} - spark-sql: rule defined in "SPARK-SQL" directly</li>
+  * <li>{@link #DfOps} - df-ops|df-opr|: data frame operations rule, support some pre-defined data frame ops()</li>
+  * <li>{@link #GriffinDsl} - griffin dsl rule, to define dq measurements easier</li>
+  */
 object DslType extends GriffinEnum {
   type DslType = Value
 
   val SparkSql, DfOps, DfOpr, DfOperations, GriffinDsl, Unknown = Value
-  //todo - removed redudant variables
+
   /**
-   *
-   * @param name Dsltype from config file
-   * @return Enum value corresponding to string
-   */
+    *
+    * @param name Dsltype from config file
+    * @return Enum value corresponding to string
+    */
   def withNameWithDslType(name: String): Value =
     values
       .find(_.toString.toLowerCase == name.replace("-", "").toLowerCase())
       .getOrElse(Value)
 
+  override def withNameWithDefault(name: String): enums.DslType.Value = {
+    val dslType = withNameWithDslType(name)
+    dslType match {
+      case DfOps | DfOpr | DfOperations => DfOperations
+      case _                            => dslType
+    }
+  }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/DslType.scala
@@ -28,7 +28,7 @@ import org.apache.griffin.measure.configuration.enums
 object DslType extends GriffinEnum {
   type DslType = Value
 
-  val SparkSql, DfOps, DfOpr, DfOperations, GriffinDsl, Unknown = Value
+  val SparkSql, DfOps, DfOpr, DfOperations, GriffinDsl = Value
 
   /**
     *
@@ -38,7 +38,7 @@ object DslType extends GriffinEnum {
   def withNameWithDslType(name: String): Value =
     values
       .find(_.toString.toLowerCase == name.replace("-", "").toLowerCase())
-      .getOrElse(Value)
+      .getOrElse(GriffinDsl)
 
   override def withNameWithDefault(name: String): enums.DslType.Value = {
     val dslType = withNameWithDslType(name)

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
@@ -55,9 +55,9 @@ object FlattenType extends GriffinEnum {
     val flattenType = super.withNameWithDefault(name)
     flattenType match {
       case Array | List => ArrayFlattenType
-      case Map          => MapFlattenType
-      case Entries      => EntriesFlattenType
-      case _            => DefaultFlattenType
+      case Map => MapFlattenType
+      case Entries => EntriesFlattenType
+      case _ => DefaultFlattenType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
@@ -15,50 +15,50 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-*/
+ */
 package org.apache.griffin.measure.configuration.enums
 
 /**
- * the strategy to flatten metric
- *  <li>{@link #DefaultFlattenType} -  default flatten strategy
- *                                     metrics contains 1 row -> flatten metric json map
- *                                     metrics contains n > 1 rows -> flatten metric json array
- *                                     n = 0: { }
- *                                     n = 1: { "col1": "value1", "col2": "value2", ... }
- *                                     n > 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
- *                                     all rows
- *  </li>
- *  <li>{@link #EntriesFlattenType} - metrics contains n rows -> flatten metric json map
- *                                    n = 0: { }
- *                                    n >= 1: { "col1": "value1", "col2": "value2", ... }
- *                                    the first row only
- *  </li>
- *  <li>{@link #ArrayFlattenType} -   metrics contains n rows -> flatten metric json array
- *                                    n = 0: { "arr-name": [ ] }
- *                                    n >= 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
- *                                    all rows
- *  </li>
- *  <li>{@link #MapFlattenType} - metrics contains n rows -> flatten metric json wrapped map
- *                                n = 0: { "map-name": { } }
- *                                n >= 1: { "map-name": { "col1": "value1", "col2": "value2", ... } }
- *                                the first row only
- *  </li>
- */
+  * the strategy to flatten metric
+  *  <li>{@link #DefaultFlattenType} -  default flatten strategy
+  *                                     metrics contains 1 row -> flatten metric json map
+  *                                     metrics contains n > 1 rows -> flatten metric json array
+  *                                     n = 0: { }
+  *                                     n = 1: { "col1": "value1", "col2": "value2", ... }
+  *                                     n > 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
+  *                                     all rows
+  *  </li>
+  *  <li>{@link #EntriesFlattenType} - metrics contains n rows -> flatten metric json map
+  *                                    n = 0: { }
+  *                                    n >= 1: { "col1": "value1", "col2": "value2", ... }
+  *                                    the first row only
+  *  </li>
+  *  <li>{@link #ArrayFlattenType} -   metrics contains n rows -> flatten metric json array
+  *                                    n = 0: { "arr-name": [ ] }
+  *                                    n >= 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
+  *                                    all rows
+  *  </li>
+  *  <li>{@link #MapFlattenType} - metrics contains n rows -> flatten metric json wrapped map
+  *                                n = 0: { "map-name": { } }
+  *                                n >= 1: { "map-name": { "col1": "value1", "col2": "value2", ... } }
+  *                                the first row only
+  *  </li>
+  */
 object FlattenType extends GriffinEnum {
   type FlattenType = Value
 
-  val DefaultFlattenType, EntriesFlattenType, ArrayFlattenType ,MapFlattenType =
+  val DefaultFlattenType, EntriesFlattenType, ArrayFlattenType, MapFlattenType =
     Value
 
-  val List,Array,Entries,Map,Default = Value
+  val List, Array, Entries, Map, Default = Value
 
-  override def withNameWithDefault(name : String): Value = {
+  override def withNameWithDefault(name: String): Value = {
     val flattenType = super.withNameWithDefault(name)
     flattenType match {
       case Array | List => ArrayFlattenType
-      case Map  => MapFlattenType
-      case Entries => EntriesFlattenType
-      case _ => DefaultFlattenType
+      case Map          => MapFlattenType
+      case Entries      => EntriesFlattenType
+      case _            => DefaultFlattenType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
@@ -47,13 +47,18 @@ package org.apache.griffin.measure.configuration.enums
 object FlattenType extends GriffinEnum {
   type FlattenType = Value
 
-  val DefaultFlattenType, EntriesFlattenType, ArrayFlattenType, MapFlattenType =
+  val DefaultFlattenType, EntriesFlattenType, ArrayFlattenType ,MapFlattenType =
     Value
 
-  def withNameFlattenType(name: String): Value = {
-    name.trim.toLowerCase match {
-      case "array" | "list" => ArrayFlattenType
-      case _ => withNameWithDefault(name)
+  val List,Array,Entries,Map,Default = Value
+
+  override def withNameWithDefault(name : String): Value = {
+    val flattenType = super.withNameWithDefault(name)
+    flattenType match {
+      case Array | List => ArrayFlattenType
+      case Map  => MapFlattenType
+      case Entries => EntriesFlattenType
+      case _ => DefaultFlattenType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/FlattenType.scala
@@ -18,77 +18,42 @@ under the License.
 */
 package org.apache.griffin.measure.configuration.enums
 
-import scala.util.matching.Regex
-
 /**
-  * the strategy to flatten metric
-  */
-sealed trait FlattenType {
-  val idPattern: Regex
-  val desc: String
-}
+ * the strategy to flatten metric
+ *  <li>{@link #DefaultFlattenType} -  default flatten strategy
+ *                                     metrics contains 1 row -> flatten metric json map
+ *                                     metrics contains n > 1 rows -> flatten metric json array
+ *                                     n = 0: { }
+ *                                     n = 1: { "col1": "value1", "col2": "value2", ... }
+ *                                     n > 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
+ *                                     all rows
+ *  </li>
+ *  <li>{@link #EntriesFlattenType} - metrics contains n rows -> flatten metric json map
+ *                                    n = 0: { }
+ *                                    n >= 1: { "col1": "value1", "col2": "value2", ... }
+ *                                    the first row only
+ *  </li>
+ *  <li>{@link #ArrayFlattenType} -   metrics contains n rows -> flatten metric json array
+ *                                    n = 0: { "arr-name": [ ] }
+ *                                    n >= 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
+ *                                    all rows
+ *  </li>
+ *  <li>{@link #MapFlattenType} - metrics contains n rows -> flatten metric json wrapped map
+ *                                n = 0: { "map-name": { } }
+ *                                n >= 1: { "map-name": { "col1": "value1", "col2": "value2", ... } }
+ *                                the first row only
+ *  </li>
+ */
+object FlattenType extends GriffinEnum {
+  type FlattenType = Value
 
-object FlattenType {
-  private val flattenTypes: List[FlattenType] = List(
-    DefaultFlattenType,
-    EntriesFlattenType,
-    ArrayFlattenType,
-    MapFlattenType
-  )
+  val DefaultFlattenType, EntriesFlattenType, ArrayFlattenType, MapFlattenType =
+    Value
 
-  val default = DefaultFlattenType
-  def apply(ptn: String): FlattenType = {
-    flattenTypes.find(tp => ptn match {
-      case tp.idPattern() => true
-      case _ => false
-    }).getOrElse(default)
+  def withNameFlattenType(name: String): Value = {
+    name.trim.toLowerCase match {
+      case "array" | "list" => ArrayFlattenType
+      case _ => withNameWithDefault(name)
+    }
   }
-  def unapply(pt: FlattenType): Option[String] = Some(pt.desc)
-}
-
-/**
-  * default flatten strategy
-  * metrics contains 1 row -> flatten metric json map
-  * metrics contains n > 1 rows -> flatten metric json array
-  * n = 0: { }
-  * n = 1: { "col1": "value1", "col2": "value2", ... }
-  * n > 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
-  * all rows
-  */
- case object DefaultFlattenType extends FlattenType {
-  val idPattern: Regex = "".r
-  val desc: String = "default"
-}
-
-/**
-  * metrics contains n rows -> flatten metric json map
-  * n = 0: { }
-  * n >= 1: { "col1": "value1", "col2": "value2", ... }
-  * the first row only
-  */
- case object EntriesFlattenType extends FlattenType {
-  val idPattern: Regex = "^(?i)entries$".r
-  val desc: String = "entries"
-}
-
-/**
-  * metrics contains n rows -> flatten metric json array
-  * n = 0: { "arr-name": [ ] }
-  * n >= 1: { "arr-name": [ { "col1": "value1", "col2": "value2", ... }, ... ] }
-  * all rows
-  */
- case object ArrayFlattenType extends FlattenType {
-  val idPattern: Regex = "^(?i)array|list$".r
-  val desc: String = "array"
-}
-
-/**
-  * metrics contains n rows -> flatten metric json wrapped map
-  * n = 0: { "map-name": { } }
-  * n >= 1: { "map-name": { "col1": "value1", "col2": "value2", ... } }
-  * the first row only
-  */
- case object MapFlattenType extends FlattenType {
-  val idPattern: Regex = "^(?i)map$".r
-  val desc: String = "map"
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
@@ -1,13 +1,16 @@
 package org.apache.griffin.measure.configuration.enums
 
 trait GriffinEnum extends Enumeration {
+  type GriffinEnum = Value
 
+  val Unknown = Value
   /**
    *
    * @param name Constant value in String
    * @return Enum constant value
    */
   def withNameWithDefault(name: String): Value =
-    values.find(_.toString.toLowerCase == name.toLowerCase()).getOrElse(Value)
+    values.find(_.toString.toLowerCase == name.replace("-", "").toLowerCase()).
+      getOrElse(Unknown)
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
@@ -1,23 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.griffin.measure.configuration.enums
 
-/*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
- */
 trait GriffinEnum extends Enumeration {
   type GriffinEnum = Value
 

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
@@ -1,16 +1,36 @@
 package org.apache.griffin.measure.configuration.enums
 
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+ */
 trait GriffinEnum extends Enumeration {
   type GriffinEnum = Value
 
   val Unknown = Value
+
   /**
-   *
-   * @param name Constant value in String
-   * @return Enum constant value
-   */
+    *
+    * @param name Constant value in String
+    * @return Enum constant value
+    */
   def withNameWithDefault(name: String): Value =
-    values.find(_.toString.toLowerCase == name.replace("-", "").toLowerCase()).
-      getOrElse(Unknown)
+    values
+      .find(_.toString.toLowerCase == name.replace("-", "").toLowerCase())
+      .getOrElse(Unknown)
 
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/GriffinEnum.scala
@@ -1,0 +1,13 @@
+package org.apache.griffin.measure.configuration.enums
+
+trait GriffinEnum extends Enumeration {
+
+  /**
+   *
+   * @param name Constant value in String
+   * @return Enum constant value
+   */
+  def withNameWithDefault(name: String): Value =
+    values.find(_.toString.toLowerCase == name.toLowerCase()).getOrElse(Value)
+
+}

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
@@ -18,66 +18,20 @@ under the License.
 */
 package org.apache.griffin.measure.configuration.enums
 
-import scala.util.matching.Regex
-
 /**
-  * the strategy to flatten metric
-  */
-sealed trait OutputType {
-  val idPattern: Regex
-  val desc: String
-}
+ * the strategy to output metric
+ *  <li>{@link #MetricOutputType} - output the rule step result as metric</li>
+ *  <li>{@link #RecordOutputType} - output the rule step result as records</li>
+ *  <li>{@link #DscUpdateOutputType} - output the rule step result to update data source cache</li>
+ *  <li>{@link #UnknownOutputType} - will not output the result </li>
+ */
+object OutputType extends GriffinEnum {
+  type OutputType = Value
 
-object OutputType {
-  private val outputTypes: List[OutputType] = List(
-    MetricOutputType,
-    RecordOutputType,
-    DscUpdateOutputType,
-    UnknownOutputType
-  )
+  val MetricOutputType, RecordOutputType, DscUpdateOutputType, UnknownOutputType = Value
 
-  val default = UnknownOutputType
-  def apply(ptn: String): OutputType = {
-    outputTypes.find(tp => ptn match {
-      case tp.idPattern() => true
-      case _ => false
-    }).getOrElse(default)
-  }
-  def unapply(pt: OutputType): Option[String] = Some(pt.desc)
-}
-
-/**
-  * metric output type
-  * output the rule step result as metric
-  */
- case object MetricOutputType extends OutputType {
-  val idPattern: Regex = "^(?i)metric$".r
-  val desc: String = "metric"
-}
-
-/**
-  * record output type
-  * output the rule step result as records
-  */
- case object RecordOutputType extends OutputType {
-  val idPattern: Regex = "^(?i)record|records$".r
-  val desc: String = "record"
-}
-
-/**
-  * data source cache update output type
-  * output the rule step result to update data source cache
-  */
- case object DscUpdateOutputType extends OutputType {
-  val idPattern: Regex = "^(?i)dsc-update$".r
-  val desc: String = "dsc-update"
-}
-
-/**
-  * unknown output type
-  * will not output the result
-  */
- case object UnknownOutputType extends OutputType {
-  val idPattern: Regex = "".r
-  val desc: String = "unknown"
+  def withNameOutputType(name: String): Value =
+    values
+      .find(_.toString.toLowerCase.contains(name.replace("-", "").toLowerCase()))
+      .getOrElse(Value)
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
@@ -15,30 +15,31 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-*/
+ */
 package org.apache.griffin.measure.configuration.enums
 
 /**
- * the strategy to output metric
- *  <li>{@link #MetricOutputType} - output the rule step result as metric</li>
- *  <li>{@link #RecordOutputType} - output the rule step result as records</li>
- *  <li>{@link #DscUpdateOutputType} - output the rule step result to update data source cache</li>
- *  <li>{@link #UnknownOutputType} - will not output the result </li>
- */
+  * the strategy to output metric
+  *  <li>{@link #MetricOutputType} - output the rule step result as metric</li>
+  *  <li>{@link #RecordOutputType} - output the rule step result as records</li>
+  *  <li>{@link #DscUpdateOutputType} - output the rule step result to update data source cache</li>
+  *  <li>{@link #UnknownOutputType} - will not output the result </li>
+  */
 object OutputType extends GriffinEnum {
   type OutputType = Value
 
-  val MetricOutputType, RecordOutputType, DscUpdateOutputType, UnknownOutputType = Value
+  val MetricOutputType, RecordOutputType, DscUpdateOutputType,
+  UnknownOutputType = Value
 
-  val Metric,Record,Records,DscUpdate = Value
+  val Metric, Record, Records, DscUpdate = Value
 
-  override def withNameWithDefault(name : String): Value = {
+  override def withNameWithDefault(name: String): Value = {
     val flattenType = super.withNameWithDefault(name)
     flattenType match {
-      case Metric  => MetricOutputType
-      case Record | Records  => RecordOutputType
-      case DscUpdate => DscUpdateOutputType
-      case _ => UnknownOutputType
+      case Metric           => MetricOutputType
+      case Record | Records => RecordOutputType
+      case DscUpdate        => DscUpdateOutputType
+      case _                => UnknownOutputType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
@@ -35,10 +35,10 @@ object OutputType extends GriffinEnum {
   override def withNameWithDefault(name: String): Value = {
     val flattenType = super.withNameWithDefault(name)
     flattenType match {
-      case Metric           => MetricOutputType
+      case Metric => MetricOutputType
       case Record | Records => RecordOutputType
-      case DscUpdate        => DscUpdateOutputType
-      case _                => UnknownOutputType
+      case DscUpdate => DscUpdateOutputType
+      case _ => UnknownOutputType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/OutputType.scala
@@ -30,8 +30,15 @@ object OutputType extends GriffinEnum {
 
   val MetricOutputType, RecordOutputType, DscUpdateOutputType, UnknownOutputType = Value
 
-  def withNameOutputType(name: String): Value =
-    values
-      .find(_.toString.toLowerCase.contains(name.replace("-", "").toLowerCase()))
-      .getOrElse(Value)
+  val Metric,Record,Records,DscUpdate = Value
+
+  override def withNameWithDefault(name : String): Value = {
+    val flattenType = super.withNameWithDefault(name)
+    flattenType match {
+      case Metric  => MetricOutputType
+      case Record | Records  => RecordOutputType
+      case DscUpdate => DscUpdateOutputType
+      case _ => UnknownOutputType
+    }
+  }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/ProcessType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/ProcessType.scala
@@ -15,14 +15,14 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-*/
+ */
 package org.apache.griffin.measure.configuration.enums
 
 /**
- * process type enum
- *  <li>{@link #BatchProcessType} - Process in batch mode </li>
- *  <li>{@link #StreamingProcessType} - Process in streaming mode</li>
- */
+  * process type enum
+  *  <li>{@link #BatchProcessType} - Process in batch mode </li>
+  *  <li>{@link #StreamingProcessType} - Process in streaming mode</li>
+  */
 object ProcessType extends GriffinEnum {
   type ProcessType = Value
 

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/ProcessType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/ProcessType.scala
@@ -18,43 +18,14 @@ under the License.
 */
 package org.apache.griffin.measure.configuration.enums
 
-import scala.util.matching.Regex
-
 /**
-  * process type enum
-  */
-sealed trait ProcessType {
-  val idPattern: Regex
-  val desc: String
-}
+ * process type enum
+ *  <li>{@link #BatchProcessType} - Process in batch mode </li>
+ *  <li>{@link #StreamingProcessType} - Process in streaming mode</li>
+ */
+object ProcessType extends GriffinEnum {
+  type ProcessType = Value
 
-object ProcessType {
-  private val procTypes: List[ProcessType] = List(
-    BatchProcessType,
-    StreamingProcessType
-  )
-
-  def apply(ptn: String): ProcessType = {
-    procTypes.find(tp => ptn match {
-      case tp.idPattern() => true
-      case _ => false
-    }).getOrElse(BatchProcessType)
-  }
-  def unapply(pt: ProcessType): Option[String] = Some(pt.desc)
-}
-
-/**
-  * process in batch mode
-  */
- case object BatchProcessType extends ProcessType {
-  val idPattern = """^(?i)batch$""".r
-  val desc = "batch"
-}
-
-/**
-  * process in streaming mode
-  */
- case object StreamingProcessType extends ProcessType {
-  val idPattern = """^(?i)streaming$""".r
-  val desc = "streaming"
+  val BatchProcessType = Value("Batch")
+  val StreamingProcessType = Value("Streaming")
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
@@ -16,13 +16,15 @@
  */
 
 package org.apache.griffin.measure.configuration.enums
+
 import org.apache.griffin.measure.configuration.enums
 
 /**
   * Supported Sink types
   *  <li>{@link #Console #Log} -  console sink, will sink metric in console (alias log)</li>
   *  <li>{@link #Hdfs} - hdfs sink, will sink metric and record in hdfs</li>
-  *  <li>{@link #Es #Elasticsearch #Http} - elasticsearch sink, will sink metric in elasticsearch (alias Es and Http)</li>
+  *  <li>{@link #Es #Elasticsearch #Http} - elasticsearch sink, will sink metric
+  *  in elasticsearch (alias Es and Http)</li>
   *  <li>{@link #Mongo #MongoDB} - mongo sink, will sink metric in mongo db (alias MongoDb)</li>
   *  <li>{@link #Custom} - custom sink (needs using extra jar-file-extension)</li>
   *  <li>{@link #Unknown} - </li>
@@ -44,10 +46,10 @@ object SinkType extends GriffinEnum {
   override def withNameWithDefault(name: String): enums.SinkType.Value = {
     val sinkType = super.withNameWithDefault(name)
     sinkType match {
-      case Console | Log             => Console
+      case Console | Log => Console
       case Es | ElasticSearch | Http => ElasticSearch
-      case MongoDB | Mongo           => MongoDB
-      case _                         => sinkType
+      case MongoDB | Mongo => MongoDB
+      case _ => sinkType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
@@ -31,8 +31,7 @@ import org.apache.griffin.measure.configuration.enums
 object SinkType extends GriffinEnum {
   type SinkType = Value
 
-  val Console, Log, Hdfs, Es, Http, ElasticSearch, MongoDB, Mongo, Custom,
-  Unknown = Value
+  val Console, Log, Hdfs, Es, Http, ElasticSearch, MongoDB, Mongo, Custom = Value
 
   def validSinkTypes(strs: Seq[String]): Seq[SinkType] = {
     val seq = strs

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
@@ -31,7 +31,8 @@ import org.apache.griffin.measure.configuration.enums
 object SinkType extends GriffinEnum {
   type SinkType = Value
 
-  val Console, Log, Hdfs, Es, Http, ElasticSearch, MongoDB, Mongo, Custom = Value
+  val Console, Log, Hdfs, Es, Http, ElasticSearch, MongoDB, Mongo, Custom =
+    Value
 
   def validSinkTypes(strs: Seq[String]): Seq[SinkType] = {
     val seq = strs
@@ -40,7 +41,6 @@ object SinkType extends GriffinEnum {
       .distinct
     if (seq.size > 0) seq else Seq(SinkType.ElasticSearch)
   }
-
 
   override def withNameWithDefault(name: String): enums.SinkType.Value = {
     val sinkType = super.withNameWithDefault(name)

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
@@ -15,39 +15,41 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
-*/
+ */
 package org.apache.griffin.measure.configuration.enums
+import org.apache.griffin.measure.configuration.enums
 
 /**
- * Supported Sink types
- *  <li>{@link #Console #Log} -  console sink, will sink metric in console (alias log)</li>
- *  <li>{@link #Hdfs} - hdfs sink, will sink metric and record in hdfs</li>
- *  <li>{@link #Es #Elasticsearch #Http} - elasticsearch sink, will sink metric in elasticsearch (alias Es and Http)</li>
- *  <li>{@link #Mongo #MongoDB} - mongo sink, will sink metric in mongo db (alias MongoDb)</li>
- *  <li>{@link #Custom} - custom sink (needs using extra jar-file-extension)</li>
- *  <li>{@link #Unknown} - </li>
- */
+  * Supported Sink types
+  *  <li>{@link #Console #Log} -  console sink, will sink metric in console (alias log)</li>
+  *  <li>{@link #Hdfs} - hdfs sink, will sink metric and record in hdfs</li>
+  *  <li>{@link #Es #Elasticsearch #Http} - elasticsearch sink, will sink metric in elasticsearch (alias Es and Http)</li>
+  *  <li>{@link #Mongo #MongoDB} - mongo sink, will sink metric in mongo db (alias MongoDb)</li>
+  *  <li>{@link #Custom} - custom sink (needs using extra jar-file-extension)</li>
+  *  <li>{@link #Unknown} - </li>
+  */
 object SinkType extends GriffinEnum {
   type SinkType = Value
 
-  val Console, Hdfs, Elasticsearch, MongoDB, Custom, Unknown = Value
+  val Console, Log, Hdfs, Es, Http, ElasticSearch, MongoDB, Mongo, Custom,
+  Unknown = Value
 
   def validSinkTypes(strs: Seq[String]): Seq[SinkType] = {
     val seq = strs
-      .map(s => SinkType.withNameSinkType(s))
+      .map(s => SinkType.withNameWithDefault(s))
       .filter(_ != SinkType.Unknown)
       .distinct
-    if (seq.size > 0) seq else Seq(SinkType.Elasticsearch)
+    if (seq.size > 0) seq else Seq(SinkType.ElasticSearch)
   }
 
-  def withNameSinkType(name: String): Value = {
-    name.trim.toLowerCase() match {
-      case "console" | "log" => Console
-      case "hdfs" => Hdfs
-      case "es" | "elasticsearch" | "http" => Elasticsearch
-      case "mongo" | "mongodb" => MongoDB
-      case "custom" => Custom
-      case _ => Unknown
+
+  override def withNameWithDefault(name: String): enums.SinkType.Value = {
+    val sinkType = super.withNameWithDefault(name)
+    sinkType match {
+      case Console | Log             => Console
+      case Es | ElasticSearch | Http => ElasticSearch
+      case MongoDB | Mongo           => MongoDB
+      case _                         => sinkType
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/SinkType.scala
@@ -18,82 +18,36 @@ under the License.
 */
 package org.apache.griffin.measure.configuration.enums
 
-import scala.util.matching.Regex
-
 /**
-  * sink type
-  */
-sealed trait SinkType {
-  val idPattern: Regex
-  val desc: String
-}
+ * Supported Sink types
+ *  <li>{@link #Console #Log} -  console sink, will sink metric in console (alias log)</li>
+ *  <li>{@link #Hdfs} - hdfs sink, will sink metric and record in hdfs</li>
+ *  <li>{@link #Es #Elasticsearch #Http} - elasticsearch sink, will sink metric in elasticsearch (alias Es and Http)</li>
+ *  <li>{@link #Mongo #MongoDB} - mongo sink, will sink metric in mongo db (alias MongoDb)</li>
+ *  <li>{@link #Custom} - custom sink (needs using extra jar-file-extension)</li>
+ *  <li>{@link #Unknown} - </li>
+ */
+object SinkType extends GriffinEnum {
+  type SinkType = Value
 
-object SinkType {
-  private val sinkTypes: List[SinkType] = List(
-    ConsoleSinkType,
-    HdfsSinkType,
-    ElasticsearchSinkType,
-    MongoSinkType,
-    CustomSinkType,
-    UnknownSinkType
-  )
-
-  def apply(ptn: String): SinkType = {
-    sinkTypes.find(tp => ptn match {
-      case tp.idPattern() => true
-      case _ => false
-    }).getOrElse(UnknownSinkType)
-  }
-
-  def unapply(pt: SinkType): Option[String] = Some(pt.desc)
+  val Console, Hdfs, Elasticsearch, MongoDB, Custom, Unknown = Value
 
   def validSinkTypes(strs: Seq[String]): Seq[SinkType] = {
-    val seq = strs.map(s => SinkType(s)).filter(_ != UnknownSinkType).distinct
-    if (seq.size > 0) seq else Seq(ElasticsearchSinkType)
+    val seq = strs
+      .map(s => SinkType.withNameSinkType(s))
+      .filter(_ != SinkType.Unknown)
+      .distinct
+    if (seq.size > 0) seq else Seq(SinkType.Elasticsearch)
   }
-}
 
-/**
-  * console sink, will sink metric in console
-  */
-case object ConsoleSinkType extends SinkType {
-  val idPattern = "^(?i)console|log$".r
-  val desc = "console"
-}
-
-/**
-  * hdfs sink, will sink metric and record in hdfs
-  */
-case object HdfsSinkType extends SinkType {
-  val idPattern = "^(?i)hdfs$".r
-  val desc = "hdfs"
-}
-
-/**
-  * elasticsearch sink, will sink metric in elasticsearch
-  */
-case object ElasticsearchSinkType extends SinkType {
-  val idPattern = "^(?i)es|elasticsearch|http$".r
-  val desc = "elasticsearch"
-}
-
-/**
-  * mongo sink, will sink metric in mongo db
-  */
-case object MongoSinkType extends SinkType {
-  val idPattern = "^(?i)mongo|mongodb$".r
-  val desc = "mongo"
-}
-
-/**
-  * custom sink (needs using extra jar-file-extension)
-  */
-case object CustomSinkType extends SinkType {
-  val idPattern = "^(?i)custom$".r
-  val desc = "custom"
-}
-
-case object UnknownSinkType extends SinkType {
-  val idPattern = "".r
-  val desc = "unknown"
+  def withNameSinkType(name: String): Value = {
+    name.trim.toLowerCase() match {
+      case "console" | "log" => Console
+      case "hdfs" => Hdfs
+      case "es" | "elasticsearch" | "http" => Elasticsearch
+      case "mongo" | "mongodb" => MongoDB
+      case "custom" => Custom
+      case _ => Unknown
+    }
+  }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/WriteMode.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/configuration/enums/WriteMode.scala
@@ -24,10 +24,10 @@ package org.apache.griffin.measure.configuration.enums
 sealed trait WriteMode {}
 
 object WriteMode {
-  def defaultMode(procType: ProcessType): WriteMode = {
+  def defaultMode(procType: ProcessType.ProcessType): WriteMode = {
     procType match {
-      case BatchProcessType => SimpleMode
-      case StreamingProcessType => TimestampMode
+      case ProcessType.BatchProcessType => SimpleMode
+      case ProcessType.StreamingProcessType => TimestampMode
     }
   }
 }

--- a/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
@@ -18,6 +18,7 @@
 package org.apache.griffin.measure.context
 
 import org.apache.spark.sql.{Encoders, SparkSession}
+
 import org.apache.griffin.measure.configuration.dqdefinition._
 import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.configuration.enums.WriteMode

--- a/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
@@ -34,7 +34,7 @@ case class DQContext(contextId: ContextId,
                      name: String,
                      dataSources: Seq[DataSource],
                      sinkParams: Seq[SinkParam],
-                     procType: ProcessType
+                     procType: ProcessType.ProcessType
                     )(@transient implicit val sparkSession: SparkSession) {
 
   val compileTableRegister: CompileTableRegister = CompileTableRegister()
@@ -87,8 +87,8 @@ case class DQContext(contextId: ContextId,
 
   private def createSink(t: Long): Sink = {
     procType match {
-      case BatchProcessType => sinkFactory.getSinks(t, true)
-      case StreamingProcessType => sinkFactory.getSinks(t, false)
+      case ProcessType.BatchProcessType => sinkFactory.getSinks(t, true)
+      case ProcessType.StreamingProcessType => sinkFactory.getSinks(t, false)
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/context/DQContext.scala
@@ -19,9 +19,9 @@ under the License.
 package org.apache.griffin.measure.context
 
 import org.apache.spark.sql.{Encoders, SparkSession}
-
 import org.apache.griffin.measure.configuration.dqdefinition._
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.WriteMode
 import org.apache.griffin.measure.datasource._
 import org.apache.griffin.measure.sink.{Sink, SinkFactory}
 
@@ -34,7 +34,7 @@ case class DQContext(contextId: ContextId,
                      name: String,
                      dataSources: Seq[DataSource],
                      sinkParams: Seq[SinkParam],
-                     procType: ProcessType.ProcessType
+                     procType: ProcessType
                     )(@transient implicit val sparkSession: SparkSession) {
 
   val compileTableRegister: CompileTableRegister = CompileTableRegister()
@@ -87,8 +87,8 @@ case class DQContext(contextId: ContextId,
 
   private def createSink(t: Long): Sink = {
     procType match {
-      case ProcessType.BatchProcessType => sinkFactory.getSinks(t, true)
-      case ProcessType.StreamingProcessType => sinkFactory.getSinks(t, false)
+      case BatchProcessType => sinkFactory.getSinks(t, true)
+      case StreamingProcessType => sinkFactory.getSinks(t, false)
     }
   }
 

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/DataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/DataConnector.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.functions._
 
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.DataConnectorParam
-import org.apache.griffin.measure.configuration.enums.BatchProcessType
+import org.apache.griffin.measure.configuration.enums.ProcessType.BatchProcessType
 import org.apache.griffin.measure.context.{ContextId, DQContext, TimeRange}
 import org.apache.griffin.measure.datasource.TimestampStorage
 import org.apache.griffin.measure.job.builder.DQJobBuilder

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
@@ -74,7 +74,7 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
 
     // create dq context
     dqContext = DQContext(
-      contextId, metricName, dataSources, sinkParams, BatchProcessType
+      contextId, metricName, dataSources, sinkParams, ProcessType.BatchProcessType
     )(sparkSession)
 
     // start id

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/batch/BatchDQApp.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
 import org.apache.griffin.measure.configuration.dqdefinition._
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.ProcessType.BatchProcessType
 import org.apache.griffin.measure.context._
 import org.apache.griffin.measure.datasource.DataSourceFactory
 import org.apache.griffin.measure.job.builder.DQJobBuilder
@@ -74,7 +74,7 @@ case class BatchDQApp(allParam: GriffinConfig) extends DQApp {
 
     // create dq context
     dqContext = DQContext(
-      contextId, metricName, dataSources, sinkParams, ProcessType.BatchProcessType
+      contextId, metricName, dataSources, sinkParams, BatchProcessType
     )(sparkSession)
 
     // start id

--- a/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/launch/streaming/StreamingDQApp.scala
@@ -29,7 +29,7 @@ import org.apache.spark.streaming.{Milliseconds, StreamingContext}
 
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition._
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.ProcessType.StreamingProcessType
 import org.apache.griffin.measure.context._
 import org.apache.griffin.measure.context.streaming.checkpoint.offset.OffsetCheckpointClient
 import org.apache.griffin.measure.context.streaming.metric.CacheResults

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/SinkFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/SinkFactory.scala
@@ -45,7 +45,7 @@ case class SinkFactory(sinkParamIter: Iterable[SinkParam],
     val sinkTry = sinkType match {
       case SinkType.Console => Try(ConsoleSink(config, metricName, timeStamp))
       case SinkType.Hdfs => Try(HdfsSink(config, metricName, timeStamp))
-      case SinkType.Elasticsearch => Try(ElasticSearchSink(config, metricName, timeStamp, block))
+      case SinkType.ElasticSearch => Try(ElasticSearchSink(config, metricName, timeStamp, block))
       case SinkType.MongoDB => Try(MongoSink(config, metricName, timeStamp, block))
       case SinkType.Custom => Try(getCustomSink(config, metricName, timeStamp, block))
       case _ => throw new Exception(s"sink type ${sinkType} is not supported!")

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/SinkFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/SinkFactory.scala
@@ -43,11 +43,11 @@ case class SinkFactory(sinkParamIter: Iterable[SinkParam],
     val config = sinkParam.getConfig
     val sinkType = sinkParam.getType
     val sinkTry = sinkType match {
-      case ConsoleSinkType => Try(ConsoleSink(config, metricName, timeStamp))
-      case HdfsSinkType => Try(HdfsSink(config, metricName, timeStamp))
-      case ElasticsearchSinkType => Try(ElasticSearchSink(config, metricName, timeStamp, block))
-      case MongoSinkType => Try(MongoSink(config, metricName, timeStamp, block))
-      case CustomSinkType => Try(getCustomSink(config, metricName, timeStamp, block))
+      case SinkType.Console => Try(ConsoleSink(config, metricName, timeStamp))
+      case SinkType.Hdfs => Try(HdfsSink(config, metricName, timeStamp))
+      case SinkType.Elasticsearch => Try(ElasticSearchSink(config, metricName, timeStamp, block))
+      case SinkType.MongoDB => Try(MongoSink(config, metricName, timeStamp, block))
+      case SinkType.Custom => Try(getCustomSink(config, metricName, timeStamp, block))
       case _ => throw new Exception(s"sink type ${sinkType} is not supported!")
     }
     sinkTry match {

--- a/measure/src/main/scala/org/apache/griffin/measure/sink/SinkFactory.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/sink/SinkFactory.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success, Try}
 
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.SinkParam
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.SinkType._
 import org.apache.griffin.measure.utils.ParamUtil._
 
 case class SinkFactory(sinkParamIter: Iterable[SinkParam],
@@ -43,11 +43,11 @@ case class SinkFactory(sinkParamIter: Iterable[SinkParam],
     val config = sinkParam.getConfig
     val sinkType = sinkParam.getType
     val sinkTry = sinkType match {
-      case SinkType.Console => Try(ConsoleSink(config, metricName, timeStamp))
-      case SinkType.Hdfs => Try(HdfsSink(config, metricName, timeStamp))
-      case SinkType.ElasticSearch => Try(ElasticSearchSink(config, metricName, timeStamp, block))
-      case SinkType.MongoDB => Try(MongoSink(config, metricName, timeStamp, block))
-      case SinkType.Custom => Try(getCustomSink(config, metricName, timeStamp, block))
+      case Console => Try(ConsoleSink(config, metricName, timeStamp))
+      case Hdfs => Try(HdfsSink(config, metricName, timeStamp))
+      case ElasticSearch => Try(ElasticSearchSink(config, metricName, timeStamp, block))
+      case MongoDB => Try(MongoSink(config, metricName, timeStamp, block))
+      case Custom => Try(getCustomSink(config, metricName, timeStamp, block))
       case _ => throw new Exception(s"sink type ${sinkType} is not supported!")
     }
     sinkTry match {

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/DQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/DQStepBuilder.scala
@@ -50,11 +50,11 @@ object DQStepBuilder {
       .flatMap(_.buildDQStep(context, dsParam))
   }
 
-  private def getDataSourceParamStepBuilder(procType: ProcessType)
+  private def getDataSourceParamStepBuilder(procType: ProcessType.ProcessType)
   : Option[DataSourceParamStepBuilder] = {
     procType match {
-      case BatchProcessType => Some(BatchDataSourceStepBuilder())
-      case StreamingProcessType => Some(StreamingDataSourceStepBuilder())
+      case ProcessType.BatchProcessType => Some(BatchDataSourceStepBuilder())
+      case ProcessType.StreamingProcessType => Some(StreamingDataSourceStepBuilder())
       case _ => None
     }
   }
@@ -72,12 +72,12 @@ object DQStepBuilder {
     dqStepOpt
   }
 
-  private def getRuleParamStepBuilder(dslType: DslType, dsNames: Seq[String], funcNames: Seq[String]
+  private def getRuleParamStepBuilder(dslType: DslType.DslType, dsNames: Seq[String], funcNames: Seq[String]
                                      ): Option[RuleParamStepBuilder] = {
     dslType match {
-      case SparkSqlType => Some(SparkSqlDQStepBuilder())
-      case DataFrameOpsType => Some(DataFrameOpsDQStepBuilder())
-      case GriffinDslType => Some(GriffinDslDQStepBuilder(dsNames, funcNames))
+      case DslType.SparkSql => Some(SparkSqlDQStepBuilder())
+      case DslType.DfOperations => Some(DataFrameOpsDQStepBuilder())
+      case DslType.GriffinDsl => Some(GriffinDslDQStepBuilder(dsNames, funcNames))
       case _ => None
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/DQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/DQStepBuilder.scala
@@ -19,10 +19,10 @@ under the License.
 package org.apache.griffin.measure.step.builder
 
 import org.apache.commons.lang.StringUtils
-
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.{DataSourceParam, Param, RuleParam}
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.DslType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step._
 
@@ -50,11 +50,11 @@ object DQStepBuilder {
       .flatMap(_.buildDQStep(context, dsParam))
   }
 
-  private def getDataSourceParamStepBuilder(procType: ProcessType.ProcessType)
+  private def getDataSourceParamStepBuilder(procType: ProcessType)
   : Option[DataSourceParamStepBuilder] = {
     procType match {
-      case ProcessType.BatchProcessType => Some(BatchDataSourceStepBuilder())
-      case ProcessType.StreamingProcessType => Some(StreamingDataSourceStepBuilder())
+      case BatchProcessType => Some(BatchDataSourceStepBuilder())
+      case StreamingProcessType => Some(StreamingDataSourceStepBuilder())
       case _ => None
     }
   }
@@ -72,12 +72,12 @@ object DQStepBuilder {
     dqStepOpt
   }
 
-  private def getRuleParamStepBuilder(dslType: DslType.DslType, dsNames: Seq[String], funcNames: Seq[String]
+  private def getRuleParamStepBuilder(dslType: DslType, dsNames: Seq[String], funcNames: Seq[String]
                                      ): Option[RuleParamStepBuilder] = {
     dslType match {
-      case DslType.SparkSql => Some(SparkSqlDQStepBuilder())
-      case DslType.DfOperations => Some(DataFrameOpsDQStepBuilder())
-      case DslType.GriffinDsl => Some(GriffinDslDQStepBuilder(dsNames, funcNames))
+      case SparkSql => Some(SparkSqlDQStepBuilder())
+      case DataFrameOpsType => Some(DataFrameOpsDQStepBuilder())
+      case GriffinDsl => Some(GriffinDslDQStepBuilder(dsNames, funcNames))
       case _ => None
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/DQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/DQStepBuilder.scala
@@ -18,10 +18,11 @@
 package org.apache.griffin.measure.step.builder
 
 import org.apache.commons.lang.StringUtils
+
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.{DataSourceParam, Param, RuleParam}
-import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.configuration.enums.DslType._
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step._
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/RuleParamStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/RuleParamStepBuilder.scala
@@ -19,7 +19,7 @@ under the License.
 package org.apache.griffin.measure.step.builder
 
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.OutputType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.{DQStep, SeqDQStep}
 import org.apache.griffin.measure.step.write.{DataSourceUpdateWriteStep, MetricWriteStep, RecordWriteStep}
@@ -43,15 +43,15 @@ trait RuleParamStepBuilder extends DQStepBuilder {
   protected def buildDirectWriteSteps(ruleParam: RuleParam): Seq[DQStep] = {
     val name = getStepName(ruleParam.getOutDfName())
     // metric writer
-    val metricSteps = ruleParam.getOutputOpt(OutputType.MetricOutputType).map { metric =>
+    val metricSteps = ruleParam.getOutputOpt(MetricOutputType).map { metric =>
       MetricWriteStep(metric.getNameOpt.getOrElse(name), name, metric.getFlatten)
     }.toSeq
     // record writer
-    val recordSteps = ruleParam.getOutputOpt(OutputType.RecordOutputType).map { record =>
+    val recordSteps = ruleParam.getOutputOpt(RecordOutputType).map { record =>
       RecordWriteStep(record.getNameOpt.getOrElse(name), name)
     }.toSeq
     // update writer
-    val dsCacheUpdateSteps = ruleParam.getOutputOpt(OutputType.DscUpdateOutputType).map { dsCacheUpdate =>
+    val dsCacheUpdateSteps = ruleParam.getOutputOpt(DscUpdateOutputType).map { dsCacheUpdate =>
       DataSourceUpdateWriteStep(dsCacheUpdate.getNameOpt.getOrElse(""), name)
     }.toSeq
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/RuleParamStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/RuleParamStepBuilder.scala
@@ -43,15 +43,15 @@ trait RuleParamStepBuilder extends DQStepBuilder {
   protected def buildDirectWriteSteps(ruleParam: RuleParam): Seq[DQStep] = {
     val name = getStepName(ruleParam.getOutDfName())
     // metric writer
-    val metricSteps = ruleParam.getOutputOpt(MetricOutputType).map { metric =>
+    val metricSteps = ruleParam.getOutputOpt(OutputType.MetricOutputType).map { metric =>
       MetricWriteStep(metric.getNameOpt.getOrElse(name), name, metric.getFlatten)
     }.toSeq
     // record writer
-    val recordSteps = ruleParam.getOutputOpt(RecordOutputType).map { record =>
+    val recordSteps = ruleParam.getOutputOpt(OutputType.RecordOutputType).map { record =>
       RecordWriteStep(record.getNameOpt.getOrElse(name), name)
     }.toSeq
     // update writer
-    val dsCacheUpdateSteps = ruleParam.getOutputOpt(DscUpdateOutputType).map { dsCacheUpdate =>
+    val dsCacheUpdateSteps = ruleParam.getOutputOpt(OutputType.DscUpdateOutputType).map { dsCacheUpdate =>
       DataSourceUpdateWriteStep(dsCacheUpdate.getNameOpt.getOrElse(""), name)
     }.toSeq
 

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/parser/GriffinDslParser.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/parser/GriffinDslParser.scala
@@ -18,8 +18,7 @@ under the License.
 */
 package org.apache.griffin.measure.step.builder.dsl.parser
 
-import org.apache.griffin.measure.configuration.enums._
-import org.apache.griffin.measure.step.builder.dsl._
+import org.apache.griffin.measure.configuration.enums.DqType._
 import org.apache.griffin.measure.step.builder.dsl.expr._
 
 /**
@@ -81,14 +80,14 @@ case class GriffinDslParser(dataSourceNames: Seq[String], functionNames: Seq[Str
     case exprs => CompletenessClause(exprs)
   }
 
-  def parseRule(rule: String, dqType: DqType.DqType): ParseResult[Expr] = {
+  def parseRule(rule: String, dqType: DqType): ParseResult[Expr] = {
     val rootExpr = dqType match {
-      case DqType.Accuracy => logicalExpression
-      case DqType.Profiling => profilingClause
-      case DqType.Uniqueness => uniquenessClause
-      case DqType.Distinct => distinctnessClause
-      case DqType.Timeliness => timelinessClause
-      case DqType.Completeness => completenessClause
+      case Accuracy => logicalExpression
+      case Profiling => profilingClause
+      case Uniqueness => uniquenessClause
+      case Distinct => distinctnessClause
+      case Timeliness => timelinessClause
+      case Completeness => completenessClause
       case _ => expression
     }
     parseAll(rootExpr, rule)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/parser/GriffinDslParser.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/parser/GriffinDslParser.scala
@@ -81,14 +81,14 @@ case class GriffinDslParser(dataSourceNames: Seq[String], functionNames: Seq[Str
     case exprs => CompletenessClause(exprs)
   }
 
-  def parseRule(rule: String, dqType: DqType): ParseResult[Expr] = {
+  def parseRule(rule: String, dqType: DqType.DqType): ParseResult[Expr] = {
     val rootExpr = dqType match {
-      case AccuracyType => logicalExpression
-      case ProfilingType => profilingClause
-      case UniquenessType => uniquenessClause
-      case DistinctnessType => distinctnessClause
-      case TimelinessType => timelinessClause
-      case CompletenessType => completenessClause
+      case DqType.Accuracy => logicalExpression
+      case DqType.Profiling => profilingClause
+      case DqType.Uniqueness => uniquenessClause
+      case DqType.Distinct => distinctnessClause
+      case DqType.Timeliness => timelinessClause
+      case DqType.Completeness => completenessClause
       case _ => expression
     }
     parseAll(rootExpr, rule)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/AccuracyExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/AccuracyExpr2DQSteps.scala
@@ -18,7 +18,7 @@
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.FlattenType.{DefaultFlattenType}
+import org.apache.griffin.measure.configuration.enums.FlattenType.DefaultFlattenType
 import org.apache.griffin.measure.configuration.enums.OutputType._
 import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
@@ -26,12 +26,8 @@ import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns
 import org.apache.griffin.measure.step.builder.dsl.expr._
 import org.apache.griffin.measure.step.builder.dsl.transform.analyzer.AccuracyAnalyzer
+import org.apache.griffin.measure.step.transform.{DataFrameOps, DataFrameOpsTransformStep, SparkSqlTransformStep}
 import org.apache.griffin.measure.step.transform.DataFrameOps.AccuracyOprKeys
-import org.apache.griffin.measure.step.transform.{
-  DataFrameOps,
-  DataFrameOpsTransformStep,
-  SparkSqlTransformStep
-}
 import org.apache.griffin.measure.step.write.{
   DataSourceUpdateWriteStep,
   MetricWriteStep,

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/CompletenessExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/CompletenessExpr2DQSteps.scala
@@ -18,10 +18,11 @@
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.commons.lang.StringUtils
+
 import org.apache.griffin.measure.configuration.dqdefinition.{RuleErrorConfParam, RuleParam}
-import org.apache.griffin.measure.configuration.enums.FlattenType.{DefaultFlattenType}
-import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.FlattenType.DefaultFlattenType
 import org.apache.griffin.measure.configuration.enums.OutputType._
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/DistinctnessExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/DistinctnessExpr2DQSteps.scala
@@ -18,9 +18,9 @@
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.FlattenType.{ArrayFlattenType, EntriesFlattenType}
 import org.apache.griffin.measure.configuration.enums.OutputType._
-import org.apache.griffin.measure.configuration.enums.FlattenType.{ArrayFlattenType,EntriesFlattenType}
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/DistinctnessExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/DistinctnessExpr2DQSteps.scala
@@ -111,7 +111,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
         s"SELECT COUNT(*) AS `${totalColName}` FROM `${sourceAliasTableName}`"
       }
       val totalMetricWriteStep = {
-        MetricWriteStep(totalColName, totalTableName, EntriesFlattenType, writeTimestampOpt)
+        MetricWriteStep(totalColName, totalTableName, FlattenType.EntriesFlattenType, writeTimestampOpt)
       }
       val totalTransStep =
         SparkSqlTransformStep(totalTableName, totalSql, emptyMap, Some(totalMetricWriteStep))
@@ -135,7 +135,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
       val transSteps1 = totalTransStep :: selfGroupTransStep :: Nil
 
       val (transSteps2, dupCountTableName) = procType match {
-        case StreamingProcessType if (withOlderTable) =>
+        case ProcessType.StreamingProcessType if (withOlderTable) =>
           // 4.0 update old data
           val targetDsUpdateWriteStep = DataSourceUpdateWriteStep(targetName, targetName)
 
@@ -226,7 +226,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
          """.stripMargin
       }
       val distMetricWriteStep = {
-        MetricWriteStep(distColName, distTableName, EntriesFlattenType, writeTimestampOpt)
+        MetricWriteStep(distColName, distTableName, FlattenType.EntriesFlattenType, writeTimestampOpt)
       }
       val distTransStep =
         SparkSqlTransformStep(distTableName, distSql, emptyMap, Some(distMetricWriteStep))
@@ -277,7 +277,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
                """.stripMargin
           }
           val dupItemsWriteStep = {
-            val rwName = ruleParam.getOutputOpt(RecordOutputType).flatMap(_.getNameOpt).getOrElse(dupItemsTableName)
+            val rwName = ruleParam.getOutputOpt(OutputType.RecordOutputType).flatMap(_.getNameOpt).getOrElse(dupItemsTableName)
             RecordWriteStep(rwName, dupItemsTableName, None, writeTimestampOpt)
           }
           val dupItemsTransStep = {
@@ -307,7 +307,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
           val groupDupMetricWriteStep = {
             MetricWriteStep(duplicationArrayName,
               groupDupMetricTableName,
-              ArrayFlattenType,
+              FlattenType.ArrayFlattenType,
               writeTimestampOpt)
           }
           val groupDupMetricTransStep =
@@ -325,7 +325,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
           // 9. duplicate record
           val dupRecordTableName = "__dupRecords"
           val dupRecordSelClause = procType match {
-            case StreamingProcessType if (withOlderTable) =>
+            case ProcessType.StreamingProcessType if (withOlderTable) =>
               s"${distAliasesClause}, `${dupColName}`, `${accuDupColName}`"
 
             case _ => s"${distAliasesClause}, `${dupColName}`"
@@ -338,7 +338,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
           }
           val dupRecordWriteStep = {
             val rwName =
-              ruleParam.getOutputOpt(RecordOutputType).flatMap(_.getNameOpt)
+              ruleParam.getOutputOpt(OutputType.RecordOutputType).flatMap(_.getNameOpt)
                 .getOrElse(dupRecordTableName)
             RecordWriteStep(rwName, dupRecordTableName, None, writeTimestampOpt)
           }
@@ -369,7 +369,7 @@ case class DistinctnessExpr2DQSteps(context: DQContext,
             MetricWriteStep(
               duplicationArrayName,
               dupMetricTableName,
-              ArrayFlattenType,
+              FlattenType.ArrayFlattenType,
               writeTimestampOpt
             )
           }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/Expr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/Expr2DQSteps.scala
@@ -20,7 +20,7 @@ package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.DqType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.dsl.expr.Expr
@@ -47,12 +47,12 @@ object Expr2DQSteps {
             ruleParam: RuleParam
            ): Expr2DQSteps = {
     ruleParam.getDqType match {
-      case DqType.Accuracy => AccuracyExpr2DQSteps(context, expr, ruleParam)
-      case DqType.Profiling => ProfilingExpr2DQSteps(context, expr, ruleParam)
-      case DqType.Uniqueness => UniquenessExpr2DQSteps(context, expr, ruleParam)
-      case DqType.Distinct => DistinctnessExpr2DQSteps(context, expr, ruleParam)
-      case DqType.Timeliness => TimelinessExpr2DQSteps(context, expr, ruleParam)
-      case DqType.Completeness => CompletenessExpr2DQSteps(context, expr, ruleParam)
+      case Accuracy => AccuracyExpr2DQSteps(context, expr, ruleParam)
+      case Profiling => ProfilingExpr2DQSteps(context, expr, ruleParam)
+      case Uniqueness => UniquenessExpr2DQSteps(context, expr, ruleParam)
+      case Distinct => DistinctnessExpr2DQSteps(context, expr, ruleParam)
+      case Timeliness => TimelinessExpr2DQSteps(context, expr, ruleParam)
+      case Completeness => CompletenessExpr2DQSteps(context, expr, ruleParam)
       case _ => emtptExpr2DQSteps
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/Expr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/Expr2DQSteps.scala
@@ -47,12 +47,12 @@ object Expr2DQSteps {
             ruleParam: RuleParam
            ): Expr2DQSteps = {
     ruleParam.getDqType match {
-      case AccuracyType => AccuracyExpr2DQSteps(context, expr, ruleParam)
-      case ProfilingType => ProfilingExpr2DQSteps(context, expr, ruleParam)
-      case UniquenessType => UniquenessExpr2DQSteps(context, expr, ruleParam)
-      case DistinctnessType => DistinctnessExpr2DQSteps(context, expr, ruleParam)
-      case TimelinessType => TimelinessExpr2DQSteps(context, expr, ruleParam)
-      case CompletenessType => CompletenessExpr2DQSteps(context, expr, ruleParam)
+      case DqType.Accuracy => AccuracyExpr2DQSteps(context, expr, ruleParam)
+      case DqType.Profiling => ProfilingExpr2DQSteps(context, expr, ruleParam)
+      case DqType.Uniqueness => UniquenessExpr2DQSteps(context, expr, ruleParam)
+      case DqType.Distinct => DistinctnessExpr2DQSteps(context, expr, ruleParam)
+      case DqType.Timeliness => TimelinessExpr2DQSteps(context, expr, ruleParam)
+      case DqType.Completeness => CompletenessExpr2DQSteps(context, expr, ruleParam)
       case _ => emtptExpr2DQSteps
     }
   }

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
@@ -20,7 +20,9 @@ package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.commons.lang.StringUtils
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.{FlattenType, OutputType, ProcessType}
+import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.OutputType._
+import org.apache.griffin.measure.configuration.enums.FlattenType.{DefaultFlattenType}
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns
@@ -72,13 +74,13 @@ case class ProfilingExpr2DQSteps(context: DQContext,
       }
       val selCondition = profilingExpr.selectClause.extraConditionOpt.map(_.desc).mkString
       val selClause = procType match {
-        case ProcessType.BatchProcessType => selExprDescs.mkString(", ")
-        case ProcessType.StreamingProcessType => (s"`${ConstantColumns.tmst}`" +: selExprDescs).mkString(", ")
+        case BatchProcessType => selExprDescs.mkString(", ")
+        case StreamingProcessType => (s"`${ConstantColumns.tmst}`" +: selExprDescs).mkString(", ")
       }
       val groupByClauseOpt = analyzer.groupbyExprOpt
       val groupbyClause = procType match {
-        case ProcessType.BatchProcessType => groupByClauseOpt.map(_.desc).getOrElse("")
-        case ProcessType.StreamingProcessType =>
+        case BatchProcessType => groupByClauseOpt.map(_.desc).getOrElse("")
+        case StreamingProcessType =>
           val tmstGroupbyClause =
             GroupbyClause(LiteralStringExpr(s"`${ConstantColumns.tmst}`") :: Nil, None)
           val mergedGroubbyClause = tmstGroupbyClause.merge(groupByClauseOpt match {
@@ -97,9 +99,9 @@ case class ProfilingExpr2DQSteps(context: DQContext,
       }
       val profilingName = ruleParam.getOutDfName()
       val profilingMetricWriteStep = {
-        val metricOpt = ruleParam.getOutputOpt(OutputType.MetricOutputType)
+        val metricOpt = ruleParam.getOutputOpt(MetricOutputType)
         val mwName = metricOpt.flatMap(_.getNameOpt).getOrElse(ruleParam.getOutDfName())
-        val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.DefaultFlattenType)
+        val flattenType = metricOpt.map(_.getFlatten).getOrElse(DefaultFlattenType)
         MetricWriteStep(mwName, profilingName, flattenType)
       }
       val profilingTransStep =

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
@@ -18,10 +18,11 @@
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.commons.lang.StringUtils
+
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.FlattenType.DefaultFlattenType
 import org.apache.griffin.measure.configuration.enums.OutputType._
-import org.apache.griffin.measure.configuration.enums.FlattenType.{DefaultFlattenType}
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/ProfilingExpr2DQSteps.scala
@@ -19,9 +19,8 @@ under the License.
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.commons.lang.StringUtils
-
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.{BatchProcessType, FlattenType, MetricOutputType, StreamingProcessType}
+import org.apache.griffin.measure.configuration.enums.{FlattenType, OutputType, ProcessType}
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns
@@ -73,13 +72,13 @@ case class ProfilingExpr2DQSteps(context: DQContext,
       }
       val selCondition = profilingExpr.selectClause.extraConditionOpt.map(_.desc).mkString
       val selClause = procType match {
-        case BatchProcessType => selExprDescs.mkString(", ")
-        case StreamingProcessType => (s"`${ConstantColumns.tmst}`" +: selExprDescs).mkString(", ")
+        case ProcessType.BatchProcessType => selExprDescs.mkString(", ")
+        case ProcessType.StreamingProcessType => (s"`${ConstantColumns.tmst}`" +: selExprDescs).mkString(", ")
       }
       val groupByClauseOpt = analyzer.groupbyExprOpt
       val groupbyClause = procType match {
-        case BatchProcessType => groupByClauseOpt.map(_.desc).getOrElse("")
-        case StreamingProcessType =>
+        case ProcessType.BatchProcessType => groupByClauseOpt.map(_.desc).getOrElse("")
+        case ProcessType.StreamingProcessType =>
           val tmstGroupbyClause =
             GroupbyClause(LiteralStringExpr(s"`${ConstantColumns.tmst}`") :: Nil, None)
           val mergedGroubbyClause = tmstGroupbyClause.merge(groupByClauseOpt match {
@@ -98,9 +97,9 @@ case class ProfilingExpr2DQSteps(context: DQContext,
       }
       val profilingName = ruleParam.getOutDfName()
       val profilingMetricWriteStep = {
-        val metricOpt = ruleParam.getOutputOpt(MetricOutputType)
+        val metricOpt = ruleParam.getOutputOpt(OutputType.MetricOutputType)
         val mwName = metricOpt.flatMap(_.getNameOpt).getOrElse(ruleParam.getOutDfName())
-        val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.default)
+        val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.DefaultFlattenType)
         MetricWriteStep(mwName, profilingName, flattenType)
       }
       val profilingTransStep =

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/TimelinessExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/TimelinessExpr2DQSteps.scala
@@ -18,9 +18,9 @@
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.FlattenType.{ArrayFlattenType, DefaultFlattenType}
 import org.apache.griffin.measure.configuration.enums.OutputType._
-import org.apache.griffin.measure.configuration.enums.FlattenType.{DefaultFlattenType,ArrayFlattenType}
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/UniquenessExpr2DQSteps.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/dsl/transform/UniquenessExpr2DQSteps.scala
@@ -18,9 +18,9 @@
 package org.apache.griffin.measure.step.builder.dsl.transform
 
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums.ProcessType._
+import org.apache.griffin.measure.configuration.enums.FlattenType.{ArrayFlattenType, EntriesFlattenType}
 import org.apache.griffin.measure.configuration.enums.OutputType._
-import org.apache.griffin.measure.configuration.enums.FlattenType.{ArrayFlattenType,EntriesFlattenType}
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.DQStep
 import org.apache.griffin.measure.step.builder.ConstantColumns

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/preproc/PreProcParamMaker.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/preproc/PreProcParamMaker.scala
@@ -47,7 +47,7 @@ object PreProcParamMaker {
     val newOutDfName = withSuffix(rule.getOutDfName(), suffix)
     val rpRule = rule.replaceInOutDfName(newInDfName, newOutDfName)
     rule.getDslType match {
-      case DataFrameOpsType => rpRule
+      case DslType.DfOperations => rpRule
       case _ =>
         val newRule = replaceDfNameSuffix(rule.getRule, rule.getInDfName(), suffix)
         rpRule.replaceRule(newRule)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/preproc/PreProcParamMaker.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/preproc/PreProcParamMaker.scala
@@ -19,7 +19,7 @@ under the License.
 package org.apache.griffin.measure.step.builder.preproc
 
 import org.apache.griffin.measure.configuration.dqdefinition.RuleParam
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.DslType._
 
 /**
   * generate each entity pre-proc params by template defined in pre-proc param
@@ -47,7 +47,7 @@ object PreProcParamMaker {
     val newOutDfName = withSuffix(rule.getOutDfName(), suffix)
     val rpRule = rule.replaceInOutDfName(newInDfName, newOutDfName)
     rule.getDslType match {
-      case DslType.DfOperations => rpRule
+      case DataFrameOpsType => rpRule
       case _ =>
         val newRule = replaceDfNameSuffix(rule.getRule, rule.getInDfName(), suffix)
         rpRule.replaceRule(newRule)

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
@@ -18,7 +18,7 @@
 package org.apache.griffin.measure.step.write
 
 import org.apache.griffin.measure.configuration.enums.{SimpleMode, TimestampMode}
-import org.apache.griffin.measure.configuration.enums.FlattenType.{FlattenType,ArrayFlattenType,DefaultFlattenType,EntriesFlattenType,MapFlattenType}
+import org.apache.griffin.measure.configuration.enums.FlattenType.{ArrayFlattenType, EntriesFlattenType, FlattenType, MapFlattenType}
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.builder.ConstantColumns
 import org.apache.griffin.measure.utils.JsonUtil

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
@@ -18,7 +18,8 @@ under the License.
 */
 package org.apache.griffin.measure.step.write
 
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.{SimpleMode, TimestampMode}
+import org.apache.griffin.measure.configuration.enums.FlattenType.{FlattenType,ArrayFlattenType,DefaultFlattenType,EntriesFlattenType,MapFlattenType}
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.step.builder.ConstantColumns
 import org.apache.griffin.measure.utils.JsonUtil
@@ -29,7 +30,7 @@ import org.apache.griffin.measure.utils.ParamUtil._
   */
 case class MetricWriteStep(name: String,
                            inputName: String,
-                           flattenType: FlattenType.FlattenType,
+                           flattenType: FlattenType,
                            writeTimestampOpt: Option[Long] = None
                           ) extends WriteStep {
 
@@ -94,12 +95,12 @@ case class MetricWriteStep(name: String,
     }
   }
 
-  private def flattenMetric(metrics: Seq[Map[String, Any]], name: String, flattenType: FlattenType.FlattenType
+  private def flattenMetric(metrics: Seq[Map[String, Any]], name: String, flattenType: FlattenType
                              ): Map[String, Any] = {
     flattenType match {
-      case FlattenType.EntriesFlattenType => metrics.headOption.getOrElse(emptyMap)
-      case FlattenType.ArrayFlattenType => Map[String, Any]((name -> metrics))
-      case FlattenType.MapFlattenType =>
+      case EntriesFlattenType => metrics.headOption.getOrElse(emptyMap)
+      case ArrayFlattenType => Map[String, Any]((name -> metrics))
+      case MapFlattenType =>
         val v = metrics.headOption.getOrElse(emptyMap)
         Map[String, Any]((name -> v))
       case _ =>

--- a/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/write/MetricWriteStep.scala
@@ -29,7 +29,7 @@ import org.apache.griffin.measure.utils.ParamUtil._
   */
 case class MetricWriteStep(name: String,
                            inputName: String,
-                           flattenType: FlattenType,
+                           flattenType: FlattenType.FlattenType,
                            writeTimestampOpt: Option[Long] = None
                           ) extends WriteStep {
 
@@ -94,12 +94,12 @@ case class MetricWriteStep(name: String,
     }
   }
 
-  private def flattenMetric(metrics: Seq[Map[String, Any]], name: String, flattenType: FlattenType
+  private def flattenMetric(metrics: Seq[Map[String, Any]], name: String, flattenType: FlattenType.FlattenType
                              ): Map[String, Any] = {
     flattenType match {
-      case EntriesFlattenType => metrics.headOption.getOrElse(emptyMap)
-      case ArrayFlattenType => Map[String, Any]((name -> metrics))
-      case MapFlattenType =>
+      case FlattenType.EntriesFlattenType => metrics.headOption.getOrElse(emptyMap)
+      case FlattenType.ArrayFlattenType => Map[String, Any]((name -> metrics))
+      case FlattenType.MapFlattenType =>
         val v = metrics.headOption.getOrElse(emptyMap)
         Map[String, Any]((name -> v))
       case _ =>

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
@@ -1,11 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.griffin.measure.configuration.dqdefinition.reader
-import org.apache.griffin.measure.configuration.dqdefinition.{
-  DQConfig,
-  EvaluateRuleParam,
-  RuleOutputParam,
-  RuleParam
-}
+
 import org.scalatest.{FlatSpec, Matchers}
+
+import org.apache.griffin.measure.configuration.dqdefinition.{DQConfig, EvaluateRuleParam, RuleOutputParam, RuleParam}
+
 
 class ParamEnumReaderSpec extends FlatSpec with Matchers {
   import org.apache.griffin.measure.configuration.enums.DslType._

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
@@ -1,6 +1,11 @@
 package org.apache.griffin.measure.configuration.dqdefinition.reader
-import org.apache.griffin.measure.configuration.dqdefinition.{DQConfig, EvaluateRuleParam, RuleOutputParam, RuleParam}
-import org.apache.griffin.measure.configuration.enums.{DqType, DslType, FlattenType, OutputType, SinkType}
+import org.apache.griffin.measure.configuration.dqdefinition.{
+  DQConfig,
+  EvaluateRuleParam,
+  RuleOutputParam,
+  RuleParam
+}
+import org.apache.griffin.measure.configuration.enums._
 import org.scalatest.{FlatSpec, Matchers}
 
 class ParamEnumReaderSpec extends FlatSpec with Matchers {
@@ -43,11 +48,6 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
       val ruleParam = new RuleParam(x, "accuracy")
       ruleParam.getDslType should not be (DslType.DfOperations)
     }
-    /*val idPattern = "^(?i)spark-?sql$".r
-    idPattern.findFirstMatchIn("spark-SQL") match {
-      case Some(_) => println("ok")
-      case None  => println("not ok")
-    }*/
   }
 
   "griffindsl" should "be returned as default dsl type" in {
@@ -56,11 +56,6 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
       val ruleParam = new RuleParam(x, "accuracy")
       ruleParam.getDslType should be(DslType.GriffinDsl)
     }
-    /*val idPattern = "^(?i)spark-?sql$".r
-    idPattern.findFirstMatchIn("spark-SQL") match {
-      case Some(_) => println("ok")
-      case None  => println("not ok")
-    }*/
   }
 
   "dqtype" should "be parsed to predefined set of values" in {
@@ -101,59 +96,97 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
   }
 
   "outputtype" should "be valid" in {
-    var ruleOutputParam = new RuleOutputParam("metric","","map")
+    var ruleOutputParam = new RuleOutputParam("metric", "", "map")
     ruleOutputParam.getOutputType should be(OutputType.MetricOutputType)
-    ruleOutputParam = new RuleOutputParam("metr","","map")
+    ruleOutputParam = new RuleOutputParam("metr", "", "map")
     ruleOutputParam.getOutputType should not be (OutputType.MetricOutputType)
-    ruleOutputParam.getOutputType should be (OutputType.UnknownOutputType)
+    ruleOutputParam.getOutputType should be(OutputType.UnknownOutputType)
 
-    ruleOutputParam = new RuleOutputParam("record","","map")
+    ruleOutputParam = new RuleOutputParam("record", "", "map")
     ruleOutputParam.getOutputType should be(OutputType.RecordOutputType)
-    ruleOutputParam = new RuleOutputParam("rec","","map")
+    ruleOutputParam = new RuleOutputParam("rec", "", "map")
     ruleOutputParam.getOutputType should not be (OutputType.RecordOutputType)
-    ruleOutputParam.getOutputType should be (OutputType.UnknownOutputType)
+    ruleOutputParam.getOutputType should be(OutputType.UnknownOutputType)
 
-    ruleOutputParam = new RuleOutputParam("dscupdate","","map")
+    ruleOutputParam = new RuleOutputParam("dscupdate", "", "map")
     ruleOutputParam.getOutputType should be(OutputType.DscUpdateOutputType)
-    ruleOutputParam = new RuleOutputParam("dsc","","map")
+    ruleOutputParam = new RuleOutputParam("dsc", "", "map")
     ruleOutputParam.getOutputType should not be (OutputType.DscUpdateOutputType)
-    ruleOutputParam.getOutputType should be (OutputType.UnknownOutputType)
+    ruleOutputParam.getOutputType should be(OutputType.UnknownOutputType)
 
   }
 
   "flattentype" should "be valid" in {
-    var ruleOutputParam = new RuleOutputParam("metric","","map")
+    var ruleOutputParam = new RuleOutputParam("metric", "", "map")
     ruleOutputParam.getFlatten should be(FlattenType.MapFlattenType)
-    ruleOutputParam = new RuleOutputParam("metric","","metr")
+    ruleOutputParam = new RuleOutputParam("metric", "", "metr")
     ruleOutputParam.getFlatten should not be (FlattenType.MapFlattenType)
-    ruleOutputParam.getFlatten should be (FlattenType.DefaultFlattenType)
+    ruleOutputParam.getFlatten should be(FlattenType.DefaultFlattenType)
 
-    ruleOutputParam = new RuleOutputParam("metric","","array")
+    ruleOutputParam = new RuleOutputParam("metric", "", "array")
     ruleOutputParam.getFlatten should be(FlattenType.ArrayFlattenType)
-    ruleOutputParam = new RuleOutputParam("metric","","list")
+    ruleOutputParam = new RuleOutputParam("metric", "", "list")
     ruleOutputParam.getFlatten should be(FlattenType.ArrayFlattenType)
-    ruleOutputParam = new RuleOutputParam("metric","","arrays")
+    ruleOutputParam = new RuleOutputParam("metric", "", "arrays")
     ruleOutputParam.getFlatten should not be (FlattenType.ArrayFlattenType)
-    ruleOutputParam.getFlatten should be (FlattenType.DefaultFlattenType)
+    ruleOutputParam.getFlatten should be(FlattenType.DefaultFlattenType)
 
-    ruleOutputParam = new RuleOutputParam("metric","","entries")
+    ruleOutputParam = new RuleOutputParam("metric", "", "entries")
     ruleOutputParam.getFlatten should be(FlattenType.EntriesFlattenType)
-    ruleOutputParam = new RuleOutputParam("metric","","entry")
+    ruleOutputParam = new RuleOutputParam("metric", "", "entry")
     ruleOutputParam.getFlatten should not be (FlattenType.EntriesFlattenType)
-    ruleOutputParam.getFlatten should be (FlattenType.DefaultFlattenType)
+    ruleOutputParam.getFlatten should be(FlattenType.DefaultFlattenType)
   }
 
   "sinktype" should "be valid" in {
     import org.mockito.Mockito._
-    var dqConfig = new DQConfig("test",1234,"",Nil,mock(classOf[EvaluateRuleParam]),List("Console","Log","CONSOLE","LOG","Es","ElasticSearch","Http","MongoDB","mongo","hdfs"))
-    dqConfig.getValidSinkTypes should be (Seq(SinkType.Console,SinkType.ElasticSearch,SinkType.MongoDB,SinkType.Hdfs))
-    dqConfig = new DQConfig("test",1234,"",Nil,mock(classOf[EvaluateRuleParam]),List("Consol","Logg"))
+    var dqConfig = new DQConfig(
+      "test",
+      1234,
+      "",
+      Nil,
+      mock(classOf[EvaluateRuleParam]),
+      List(
+        "Console",
+        "Log",
+        "CONSOLE",
+        "LOG",
+        "Es",
+        "ElasticSearch",
+        "Http",
+        "MongoDB",
+        "mongo",
+        "hdfs"
+      )
+    )
+    dqConfig.getValidSinkTypes should be(
+      Seq(
+        SinkType.Console,
+        SinkType.ElasticSearch,
+        SinkType.MongoDB,
+        SinkType.Hdfs
+      )
+    )
+    dqConfig = new DQConfig(
+      "test",
+      1234,
+      "",
+      Nil,
+      mock(classOf[EvaluateRuleParam]),
+      List("Consol", "Logg")
+    )
     dqConfig.getValidSinkTypes should not be (Seq(SinkType.Console))
-    dqConfig.getValidSinkTypes should be (Seq(SinkType.ElasticSearch))
+    dqConfig.getValidSinkTypes should be(Seq(SinkType.ElasticSearch))
 
-
-    dqConfig = new DQConfig("test",1234,"",Nil,mock(classOf[EvaluateRuleParam]),List(""))
-    dqConfig.getValidSinkTypes should be (Seq(SinkType.ElasticSearch))
+    dqConfig = new DQConfig(
+      "test",
+      1234,
+      "",
+      Nil,
+      mock(classOf[EvaluateRuleParam]),
+      List("")
+    )
+    dqConfig.getValidSinkTypes should be(Seq(SinkType.ElasticSearch))
   }
 
 }

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
@@ -1,0 +1,159 @@
+package org.apache.griffin.measure.configuration.dqdefinition.reader
+import org.apache.griffin.measure.configuration.dqdefinition.{DQConfig, EvaluateRuleParam, RuleOutputParam, RuleParam}
+import org.apache.griffin.measure.configuration.enums.{DqType, DslType, FlattenType, OutputType, SinkType}
+import org.scalatest.{FlatSpec, Matchers}
+
+class ParamEnumReaderSpec extends FlatSpec with Matchers {
+  "dsltype" should "be parsed to predefined set of values" in {
+    val validDslSparkSqlValues =
+      Seq("spark-sql", "spark-SQL", "SPARK-SQL", "sparksql")
+    validDslSparkSqlValues foreach { x =>
+      val ruleParam = new RuleParam(x, "accuracy")
+      ruleParam.getDslType should ===(DslType.SparkSql)
+    }
+    val invalidDslSparkSqlValues = Seq("spark", "sql", "")
+    invalidDslSparkSqlValues foreach { x =>
+      val ruleParam = new RuleParam(x, "accuracy")
+      ruleParam.getDslType should not be (DslType.SparkSql)
+    }
+
+    val validDslGriffinValues =
+      Seq("griffin-dsl", "griffindsl", "griFfin-dsl", "")
+    validDslGriffinValues foreach { x =>
+      val ruleParam = new RuleParam(x, "accuracy")
+      ruleParam.getDslType should ===(DslType.GriffinDsl)
+    }
+
+    val validDslDfOpsValues = Seq(
+      "df-ops",
+      "dfops",
+      "DFOPS",
+      "df-opr",
+      "dfopr",
+      "df-operations",
+      "dfoperations"
+    )
+    validDslDfOpsValues foreach { x =>
+      val ruleParam = new RuleParam(x, "accuracy")
+      ruleParam.getDslType should ===(DslType.DfOperations)
+    }
+
+    val invalidDslDfOpsValues = Seq("df-oprts", "-")
+    invalidDslDfOpsValues foreach { x =>
+      val ruleParam = new RuleParam(x, "accuracy")
+      ruleParam.getDslType should not be (DslType.DfOperations)
+    }
+    /*val idPattern = "^(?i)spark-?sql$".r
+    idPattern.findFirstMatchIn("spark-SQL") match {
+      case Some(_) => println("ok")
+      case None  => println("not ok")
+    }*/
+  }
+
+  "griffindsl" should "be returned as default dsl type" in {
+    val dslGriffinDslValues = Seq("griffin", "dsl")
+    dslGriffinDslValues foreach { x =>
+      val ruleParam = new RuleParam(x, "accuracy")
+      ruleParam.getDslType should be(DslType.GriffinDsl)
+    }
+    /*val idPattern = "^(?i)spark-?sql$".r
+    idPattern.findFirstMatchIn("spark-SQL") match {
+      case Some(_) => println("ok")
+      case None  => println("not ok")
+    }*/
+  }
+
+  "dqtype" should "be parsed to predefined set of values" in {
+    var ruleParam = new RuleParam("griffin-dsl", "accuracy")
+    ruleParam.getDqType should be(DqType.Accuracy)
+    ruleParam = new RuleParam("griffin-dsl", "accu")
+    ruleParam.getDqType should not be (DqType.Accuracy)
+
+    ruleParam = new RuleParam("griffin-dsl", "profiling")
+    ruleParam.getDqType should be(DqType.Profiling)
+    ruleParam = new RuleParam("griffin-dsl", "profilin")
+    ruleParam.getDqType should not be (DqType.Profiling)
+
+    ruleParam = new RuleParam("griffin-dsl", "TIMELINESS")
+    ruleParam.getDqType should be(DqType.Timeliness)
+    ruleParam = new RuleParam("griffin-dsl", "timeliness ")
+    ruleParam.getDqType should not be (DqType.Timeliness)
+
+    ruleParam = new RuleParam("griffin-dsl", "UNIQUENESS")
+    ruleParam.getDqType should be(DqType.Uniqueness)
+    ruleParam = new RuleParam("griffin-dsl", "UNIQUE")
+    ruleParam.getDqType should not be (DqType.Uniqueness)
+
+    ruleParam = new RuleParam("griffin-dsl", "Duplicate")
+    ruleParam.getDqType should be(DqType.Uniqueness)
+    ruleParam = new RuleParam("griffin-dsl", "duplica")
+    ruleParam.getDqType should not be (DqType.Duplicate)
+
+    ruleParam = new RuleParam("griffin-dsl", "COMPLETENESS")
+    ruleParam.getDqType should be(DqType.Completeness)
+    ruleParam = new RuleParam("griffin-dsl", "complete")
+    ruleParam.getDqType should not be (DqType.Completeness)
+
+    ruleParam = new RuleParam("griffin-dsl", "")
+    ruleParam.getDqType should be(DqType.Unknown)
+    ruleParam = new RuleParam("griffin-dsl", "duplicate")
+    ruleParam.getDqType should not be (DqType.Unknown)
+  }
+
+  "outputtype" should "be valid" in {
+    var ruleOutputParam = new RuleOutputParam("metric","","map")
+    ruleOutputParam.getOutputType should be(OutputType.MetricOutputType)
+    ruleOutputParam = new RuleOutputParam("metr","","map")
+    ruleOutputParam.getOutputType should not be (OutputType.MetricOutputType)
+    ruleOutputParam.getOutputType should be (OutputType.UnknownOutputType)
+
+    ruleOutputParam = new RuleOutputParam("record","","map")
+    ruleOutputParam.getOutputType should be(OutputType.RecordOutputType)
+    ruleOutputParam = new RuleOutputParam("rec","","map")
+    ruleOutputParam.getOutputType should not be (OutputType.RecordOutputType)
+    ruleOutputParam.getOutputType should be (OutputType.UnknownOutputType)
+
+    ruleOutputParam = new RuleOutputParam("dscupdate","","map")
+    ruleOutputParam.getOutputType should be(OutputType.DscUpdateOutputType)
+    ruleOutputParam = new RuleOutputParam("dsc","","map")
+    ruleOutputParam.getOutputType should not be (OutputType.DscUpdateOutputType)
+    ruleOutputParam.getOutputType should be (OutputType.UnknownOutputType)
+
+  }
+
+  "flattentype" should "be valid" in {
+    var ruleOutputParam = new RuleOutputParam("metric","","map")
+    ruleOutputParam.getFlatten should be(FlattenType.MapFlattenType)
+    ruleOutputParam = new RuleOutputParam("metric","","metr")
+    ruleOutputParam.getFlatten should not be (FlattenType.MapFlattenType)
+    ruleOutputParam.getFlatten should be (FlattenType.DefaultFlattenType)
+
+    ruleOutputParam = new RuleOutputParam("metric","","array")
+    ruleOutputParam.getFlatten should be(FlattenType.ArrayFlattenType)
+    ruleOutputParam = new RuleOutputParam("metric","","list")
+    ruleOutputParam.getFlatten should be(FlattenType.ArrayFlattenType)
+    ruleOutputParam = new RuleOutputParam("metric","","arrays")
+    ruleOutputParam.getFlatten should not be (FlattenType.ArrayFlattenType)
+    ruleOutputParam.getFlatten should be (FlattenType.DefaultFlattenType)
+
+    ruleOutputParam = new RuleOutputParam("metric","","entries")
+    ruleOutputParam.getFlatten should be(FlattenType.EntriesFlattenType)
+    ruleOutputParam = new RuleOutputParam("metric","","entry")
+    ruleOutputParam.getFlatten should not be (FlattenType.EntriesFlattenType)
+    ruleOutputParam.getFlatten should be (FlattenType.DefaultFlattenType)
+  }
+
+  "sinktype" should "be valid" in {
+    import org.mockito.Mockito._
+    var dqConfig = new DQConfig("test",1234,"",Nil,mock(classOf[EvaluateRuleParam]),List("Console","Log","CONSOLE","LOG","Es","ElasticSearch","Http","MongoDB","mongo","hdfs"))
+    dqConfig.getValidSinkTypes should be (Seq(SinkType.Console,SinkType.ElasticSearch,SinkType.MongoDB,SinkType.Hdfs))
+    dqConfig = new DQConfig("test",1234,"",Nil,mock(classOf[EvaluateRuleParam]),List("Consol","Logg"))
+    dqConfig.getValidSinkTypes should not be (Seq(SinkType.Console))
+    dqConfig.getValidSinkTypes should be (Seq(SinkType.ElasticSearch))
+
+
+    dqConfig = new DQConfig("test",1234,"",Nil,mock(classOf[EvaluateRuleParam]),List(""))
+    dqConfig.getValidSinkTypes should be (Seq(SinkType.ElasticSearch))
+  }
+
+}

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
@@ -5,28 +5,28 @@ import org.apache.griffin.measure.configuration.dqdefinition.{
   RuleOutputParam,
   RuleParam
 }
-import org.apache.griffin.measure.configuration.enums._
 import org.scalatest.{FlatSpec, Matchers}
 
 class ParamEnumReaderSpec extends FlatSpec with Matchers {
+  import org.apache.griffin.measure.configuration.enums.DslType._
   "dsltype" should "be parsed to predefined set of values" in {
     val validDslSparkSqlValues =
       Seq("spark-sql", "spark-SQL", "SPARK-SQL", "sparksql")
     validDslSparkSqlValues foreach { x =>
       val ruleParam = new RuleParam(x, "accuracy")
-      ruleParam.getDslType should ===(DslType.SparkSql)
+      ruleParam.getDslType should ===(SparkSql)
     }
     val invalidDslSparkSqlValues = Seq("spark", "sql", "")
     invalidDslSparkSqlValues foreach { x =>
       val ruleParam = new RuleParam(x, "accuracy")
-      ruleParam.getDslType should not be (DslType.SparkSql)
+      ruleParam.getDslType should not be (SparkSql)
     }
 
     val validDslGriffinValues =
       Seq("griffin-dsl", "griffindsl", "griFfin-dsl", "")
     validDslGriffinValues foreach { x =>
       val ruleParam = new RuleParam(x, "accuracy")
-      ruleParam.getDslType should ===(DslType.GriffinDsl)
+      ruleParam.getDslType should ===(GriffinDsl)
     }
 
     val validDslDfOpsValues = Seq(
@@ -40,106 +40,111 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
     )
     validDslDfOpsValues foreach { x =>
       val ruleParam = new RuleParam(x, "accuracy")
-      ruleParam.getDslType should ===(DslType.DfOperations)
+      ruleParam.getDslType should ===(DataFrameOpsType)
     }
 
     val invalidDslDfOpsValues = Seq("df-oprts", "-")
     invalidDslDfOpsValues foreach { x =>
       val ruleParam = new RuleParam(x, "accuracy")
-      ruleParam.getDslType should not be (DslType.DfOperations)
+      ruleParam.getDslType should not be (DataFrameOpsType)
     }
   }
 
   "griffindsl" should "be returned as default dsl type" in {
+    import org.apache.griffin.measure.configuration.enums.DslType._
     val dslGriffinDslValues = Seq("griffin", "dsl")
     dslGriffinDslValues foreach { x =>
       val ruleParam = new RuleParam(x, "accuracy")
-      ruleParam.getDslType should be(DslType.GriffinDsl)
+      ruleParam.getDslType should be(GriffinDsl)
     }
   }
 
   "dqtype" should "be parsed to predefined set of values" in {
+    import org.apache.griffin.measure.configuration.enums.DqType._
     var ruleParam = new RuleParam("griffin-dsl", "accuracy")
-    ruleParam.getDqType should be(DqType.Accuracy)
+    ruleParam.getDqType should be(Accuracy)
     ruleParam = new RuleParam("griffin-dsl", "accu")
-    ruleParam.getDqType should not be (DqType.Accuracy)
+    ruleParam.getDqType should not be (Accuracy)
 
     ruleParam = new RuleParam("griffin-dsl", "profiling")
-    ruleParam.getDqType should be(DqType.Profiling)
+    ruleParam.getDqType should be(Profiling)
     ruleParam = new RuleParam("griffin-dsl", "profilin")
-    ruleParam.getDqType should not be (DqType.Profiling)
+    ruleParam.getDqType should not be (Profiling)
 
     ruleParam = new RuleParam("griffin-dsl", "TIMELINESS")
-    ruleParam.getDqType should be(DqType.Timeliness)
+    ruleParam.getDqType should be(Timeliness)
     ruleParam = new RuleParam("griffin-dsl", "timeliness ")
-    ruleParam.getDqType should not be (DqType.Timeliness)
+    ruleParam.getDqType should not be (Timeliness)
 
     ruleParam = new RuleParam("griffin-dsl", "UNIQUENESS")
-    ruleParam.getDqType should be(DqType.Uniqueness)
+    ruleParam.getDqType should be(Uniqueness)
     ruleParam = new RuleParam("griffin-dsl", "UNIQUE")
-    ruleParam.getDqType should not be (DqType.Uniqueness)
+    ruleParam.getDqType should not be (Uniqueness)
 
     ruleParam = new RuleParam("griffin-dsl", "Duplicate")
-    ruleParam.getDqType should be(DqType.Uniqueness)
+    ruleParam.getDqType should be(Uniqueness)
     ruleParam = new RuleParam("griffin-dsl", "duplica")
-    ruleParam.getDqType should not be (DqType.Duplicate)
+    ruleParam.getDqType should not be (Duplicate)
 
     ruleParam = new RuleParam("griffin-dsl", "COMPLETENESS")
-    ruleParam.getDqType should be(DqType.Completeness)
+    ruleParam.getDqType should be(Completeness)
     ruleParam = new RuleParam("griffin-dsl", "complete")
-    ruleParam.getDqType should not be (DqType.Completeness)
+    ruleParam.getDqType should not be (Completeness)
 
     ruleParam = new RuleParam("griffin-dsl", "")
-    ruleParam.getDqType should be(DqType.Unknown)
+    ruleParam.getDqType should be(Unknown)
     ruleParam = new RuleParam("griffin-dsl", "duplicate")
-    ruleParam.getDqType should not be (DqType.Unknown)
+    ruleParam.getDqType should not be (Unknown)
   }
 
   "outputtype" should "be valid" in {
+    import org.apache.griffin.measure.configuration.enums.OutputType._
     var ruleOutputParam = new RuleOutputParam("metric", "", "map")
-    ruleOutputParam.getOutputType should be(OutputType.MetricOutputType)
+    ruleOutputParam.getOutputType should be(MetricOutputType)
     ruleOutputParam = new RuleOutputParam("metr", "", "map")
-    ruleOutputParam.getOutputType should not be (OutputType.MetricOutputType)
-    ruleOutputParam.getOutputType should be(OutputType.UnknownOutputType)
+    ruleOutputParam.getOutputType should not be (MetricOutputType)
+    ruleOutputParam.getOutputType should be(UnknownOutputType)
 
     ruleOutputParam = new RuleOutputParam("record", "", "map")
-    ruleOutputParam.getOutputType should be(OutputType.RecordOutputType)
+    ruleOutputParam.getOutputType should be(RecordOutputType)
     ruleOutputParam = new RuleOutputParam("rec", "", "map")
-    ruleOutputParam.getOutputType should not be (OutputType.RecordOutputType)
-    ruleOutputParam.getOutputType should be(OutputType.UnknownOutputType)
+    ruleOutputParam.getOutputType should not be (RecordOutputType)
+    ruleOutputParam.getOutputType should be(UnknownOutputType)
 
     ruleOutputParam = new RuleOutputParam("dscupdate", "", "map")
-    ruleOutputParam.getOutputType should be(OutputType.DscUpdateOutputType)
+    ruleOutputParam.getOutputType should be(DscUpdateOutputType)
     ruleOutputParam = new RuleOutputParam("dsc", "", "map")
-    ruleOutputParam.getOutputType should not be (OutputType.DscUpdateOutputType)
-    ruleOutputParam.getOutputType should be(OutputType.UnknownOutputType)
+    ruleOutputParam.getOutputType should not be (DscUpdateOutputType)
+    ruleOutputParam.getOutputType should be(UnknownOutputType)
 
   }
 
   "flattentype" should "be valid" in {
+    import org.apache.griffin.measure.configuration.enums.FlattenType._
     var ruleOutputParam = new RuleOutputParam("metric", "", "map")
-    ruleOutputParam.getFlatten should be(FlattenType.MapFlattenType)
+    ruleOutputParam.getFlatten should be(MapFlattenType)
     ruleOutputParam = new RuleOutputParam("metric", "", "metr")
-    ruleOutputParam.getFlatten should not be (FlattenType.MapFlattenType)
-    ruleOutputParam.getFlatten should be(FlattenType.DefaultFlattenType)
+    ruleOutputParam.getFlatten should not be (MapFlattenType)
+    ruleOutputParam.getFlatten should be(DefaultFlattenType)
 
     ruleOutputParam = new RuleOutputParam("metric", "", "array")
-    ruleOutputParam.getFlatten should be(FlattenType.ArrayFlattenType)
+    ruleOutputParam.getFlatten should be(ArrayFlattenType)
     ruleOutputParam = new RuleOutputParam("metric", "", "list")
-    ruleOutputParam.getFlatten should be(FlattenType.ArrayFlattenType)
+    ruleOutputParam.getFlatten should be(ArrayFlattenType)
     ruleOutputParam = new RuleOutputParam("metric", "", "arrays")
-    ruleOutputParam.getFlatten should not be (FlattenType.ArrayFlattenType)
-    ruleOutputParam.getFlatten should be(FlattenType.DefaultFlattenType)
+    ruleOutputParam.getFlatten should not be (ArrayFlattenType)
+    ruleOutputParam.getFlatten should be(DefaultFlattenType)
 
     ruleOutputParam = new RuleOutputParam("metric", "", "entries")
-    ruleOutputParam.getFlatten should be(FlattenType.EntriesFlattenType)
+    ruleOutputParam.getFlatten should be(EntriesFlattenType)
     ruleOutputParam = new RuleOutputParam("metric", "", "entry")
-    ruleOutputParam.getFlatten should not be (FlattenType.EntriesFlattenType)
-    ruleOutputParam.getFlatten should be(FlattenType.DefaultFlattenType)
+    ruleOutputParam.getFlatten should not be (EntriesFlattenType)
+    ruleOutputParam.getFlatten should be(DefaultFlattenType)
   }
 
   "sinktype" should "be valid" in {
     import org.mockito.Mockito._
+    import org.apache.griffin.measure.configuration.enums.SinkType._
     var dqConfig = new DQConfig(
       "test",
       1234,
@@ -161,10 +166,10 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
     )
     dqConfig.getValidSinkTypes should be(
       Seq(
-        SinkType.Console,
-        SinkType.ElasticSearch,
-        SinkType.MongoDB,
-        SinkType.Hdfs
+        Console,
+        ElasticSearch,
+        MongoDB,
+        Hdfs
       )
     )
     dqConfig = new DQConfig(
@@ -175,8 +180,8 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
       mock(classOf[EvaluateRuleParam]),
       List("Consol", "Logg")
     )
-    dqConfig.getValidSinkTypes should not be (Seq(SinkType.Console))
-    dqConfig.getValidSinkTypes should be(Seq(SinkType.ElasticSearch))
+    dqConfig.getValidSinkTypes should not be (Seq(Console))
+    dqConfig.getValidSinkTypes should be(Seq(ElasticSearch))
 
     dqConfig = new DQConfig(
       "test",
@@ -186,7 +191,7 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
       mock(classOf[EvaluateRuleParam]),
       List("")
     )
-    dqConfig.getValidSinkTypes should be(Seq(SinkType.ElasticSearch))
+    dqConfig.getValidSinkTypes should be(Seq(ElasticSearch))
   }
 
 }

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamEnumReaderSpec.scala
@@ -80,31 +80,37 @@ class ParamEnumReaderSpec extends FlatSpec with Matchers {
     ruleParam.getDqType should be(Accuracy)
     ruleParam = new RuleParam("griffin-dsl", "accu")
     ruleParam.getDqType should not be (Accuracy)
+    ruleParam.getDqType should be(Unknown)
 
     ruleParam = new RuleParam("griffin-dsl", "profiling")
     ruleParam.getDqType should be(Profiling)
     ruleParam = new RuleParam("griffin-dsl", "profilin")
     ruleParam.getDqType should not be (Profiling)
+    ruleParam.getDqType should be(Unknown)
 
     ruleParam = new RuleParam("griffin-dsl", "TIMELINESS")
     ruleParam.getDqType should be(Timeliness)
     ruleParam = new RuleParam("griffin-dsl", "timeliness ")
     ruleParam.getDqType should not be (Timeliness)
+    ruleParam.getDqType should be(Unknown)
 
     ruleParam = new RuleParam("griffin-dsl", "UNIQUENESS")
     ruleParam.getDqType should be(Uniqueness)
     ruleParam = new RuleParam("griffin-dsl", "UNIQUE")
     ruleParam.getDqType should not be (Uniqueness)
+    ruleParam.getDqType should be(Unknown)
 
     ruleParam = new RuleParam("griffin-dsl", "Duplicate")
     ruleParam.getDqType should be(Uniqueness)
     ruleParam = new RuleParam("griffin-dsl", "duplica")
     ruleParam.getDqType should not be (Duplicate)
+    ruleParam.getDqType should be(Unknown)
 
     ruleParam = new RuleParam("griffin-dsl", "COMPLETENESS")
     ruleParam.getDqType should be(Completeness)
     ruleParam = new RuleParam("griffin-dsl", "complete")
     ruleParam.getDqType should not be (Completeness)
+    ruleParam.getDqType should be(Unknown)
 
     ruleParam = new RuleParam("griffin-dsl", "")
     ruleParam.getDqType should be(Unknown)

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamFileReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamFileReaderSpec.scala
@@ -19,8 +19,8 @@ under the License.
 
 package org.apache.griffin.measure.configuration.dqdefinition.reader
 import org.apache.griffin.measure.configuration.dqdefinition.DQConfig
+import org.apache.griffin.measure.configuration.enums.DslType
 import org.scalatest._
-
 
 import scala.util.{Failure, Success}
 
@@ -32,7 +32,7 @@ class ParamFileReaderSpec extends FlatSpec with Matchers{
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>
-        v.getEvaluateRule.getRules(0).getDslType.desc should === ("griffin-dsl")
+        v.getEvaluateRule.getRules(0).getDslType should === (DslType.GriffinDsl)
         v.getEvaluateRule.getRules(0).getOutDfName() should === ("accu")
       case Failure(_) =>
         fail("it should not happen")

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamFileReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamFileReaderSpec.scala
@@ -17,17 +17,18 @@
 
 package org.apache.griffin.measure.configuration.dqdefinition.reader
 
+import org.scalatest._
+import scala.util.{Failure, Success}
+
 import org.apache.griffin.measure.configuration.dqdefinition.DQConfig
 import org.apache.griffin.measure.configuration.enums.DslType.GriffinDsl
-import org.scalatest._
 
-import scala.util.{Failure, Success}
 
 class ParamFileReaderSpec extends FlatSpec with Matchers{
 
 
   "params " should "be parsed from a valid file" in {
-    val reader :ParamReader = ParamFileReader(getClass.getResource("/_accuracy-batch-griffindsl.json").getFile)
+    val reader: ParamReader = ParamFileReader(getClass.getResource("/_accuracy-batch-griffindsl.json").getFile)
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>
@@ -40,7 +41,8 @@ class ParamFileReaderSpec extends FlatSpec with Matchers{
   }
 
   it should "fail for an invalid file" in {
-    val reader :ParamReader = ParamFileReader(getClass.getResource("/invalidconfigs/missingrule_accuracy_batch_sparksql.json").getFile)
+    val reader: ParamReader = ParamFileReader(getClass.
+      getResource("/invalidconfigs/missingrule_accuracy_batch_sparksql.json").getFile)
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(_) =>
@@ -52,7 +54,8 @@ class ParamFileReaderSpec extends FlatSpec with Matchers{
   }
 
   it should "fail for an invalid completeness json file" in {
-    val reader: ParamFileReader = ParamFileReader(getClass.getResource("/invalidconfigs/invalidtype_completeness_batch_griffindal.json").getFile)
+    val reader: ParamFileReader = ParamFileReader(getClass.
+      getResource("/invalidconfigs/invalidtype_completeness_batch_griffindal.json").getFile)
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(_) =>
@@ -63,7 +66,8 @@ class ParamFileReaderSpec extends FlatSpec with Matchers{
   }
 
   it should "be parsed from a valid errorconf completeness json file" in {
-    val reader :ParamReader = ParamFileReader(getClass.getResource("/_completeness_errorconf-batch-griffindsl.json").getFile)
+    val reader: ParamReader = ParamFileReader(getClass.
+      getResource("/_completeness_errorconf-batch-griffindsl.json").getFile)
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamFileReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamFileReaderSpec.scala
@@ -19,7 +19,7 @@ under the License.
 
 package org.apache.griffin.measure.configuration.dqdefinition.reader
 import org.apache.griffin.measure.configuration.dqdefinition.DQConfig
-import org.apache.griffin.measure.configuration.enums.DslType
+import org.apache.griffin.measure.configuration.enums.DslType.GriffinDsl
 import org.scalatest._
 
 import scala.util.{Failure, Success}
@@ -32,7 +32,7 @@ class ParamFileReaderSpec extends FlatSpec with Matchers{
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>
-        v.getEvaluateRule.getRules(0).getDslType should === (DslType.GriffinDsl)
+        v.getEvaluateRule.getRules(0).getDslType should === (GriffinDsl)
         v.getEvaluateRule.getRules(0).getOutDfName() should === ("accu")
       case Failure(_) =>
         fail("it should not happen")

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamJsonReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamJsonReaderSpec.scala
@@ -19,6 +19,7 @@ under the License.
 package org.apache.griffin.measure.configuration.dqdefinition.reader
 
 import org.apache.griffin.measure.configuration.dqdefinition.DQConfig
+import org.apache.griffin.measure.configuration.enums.DslType
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.io.Source
@@ -36,7 +37,7 @@ class ParamJsonReaderSpec extends FlatSpec with Matchers{
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>
-        v.getEvaluateRule.getRules(0).getDslType.desc should === ("griffin-dsl")
+        v.getEvaluateRule.getRules(0).getDslType should === (DslType.GriffinDsl)
         v.getEvaluateRule.getRules(0).getOutDfName() should === ("accu")
       case Failure(_) =>
         fail("it should not happen")

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamJsonReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamJsonReaderSpec.scala
@@ -17,12 +17,14 @@
 
 package org.apache.griffin.measure.configuration.dqdefinition.reader
 
+import scala.io.Source
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.util.{Failure, Success}
+
 import org.apache.griffin.measure.configuration.dqdefinition.DQConfig
 import org.apache.griffin.measure.configuration.enums.DslType.GriffinDsl
-import org.scalatest.{FlatSpec, Matchers}
 
-import scala.io.Source
-import scala.util.{Failure, Success}
 
 class ParamJsonReaderSpec extends FlatSpec with Matchers{
 
@@ -32,7 +34,7 @@ class ParamJsonReaderSpec extends FlatSpec with Matchers{
     val jsonString = bufferedSource.getLines().mkString
     bufferedSource.close
 
-    val reader :ParamReader = ParamJsonReader(jsonString)
+    val reader: ParamReader = ParamJsonReader(jsonString)
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>
@@ -45,11 +47,12 @@ class ParamJsonReaderSpec extends FlatSpec with Matchers{
   }
 
   it should "fail for an invalid file" in {
-    val bufferedSource = Source.fromFile(getClass.getResource("/invalidconfigs/missingrule_accuracy_batch_sparksql.json").getFile)
+    val bufferedSource = Source.fromFile(getClass.
+      getResource("/invalidconfigs/missingrule_accuracy_batch_sparksql.json").getFile)
     val jsonString = bufferedSource.getLines().mkString
     bufferedSource.close
 
-    val reader :ParamReader = ParamJsonReader(jsonString)
+    val reader: ParamReader = ParamJsonReader(jsonString)
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(_) =>

--- a/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamJsonReaderSpec.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/configuration/dqdefinition/reader/ParamJsonReaderSpec.scala
@@ -19,7 +19,7 @@ under the License.
 package org.apache.griffin.measure.configuration.dqdefinition.reader
 
 import org.apache.griffin.measure.configuration.dqdefinition.DQConfig
-import org.apache.griffin.measure.configuration.enums.DslType
+import org.apache.griffin.measure.configuration.enums.DslType.GriffinDsl
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.io.Source
@@ -37,7 +37,7 @@ class ParamJsonReaderSpec extends FlatSpec with Matchers{
     val params = reader.readConfig[DQConfig]
     params match {
       case Success(v) =>
-        v.getEvaluateRule.getRules(0).getDslType should === (DslType.GriffinDsl)
+        v.getEvaluateRule.getRules(0).getDslType should === (GriffinDsl)
         v.getEvaluateRule.getRules(0).getOutDfName() should === ("accu")
       case Failure(_) =>
         fail("it should not happen")

--- a/measure/src/test/scala/org/apache/griffin/measure/job/DQAppTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/job/DQAppTest.scala
@@ -56,10 +56,10 @@ class DQAppTest extends FlatSpec with SparkSuiteBase with BeforeAndAfterAll with
     val allParam: GriffinConfig = GriffinConfig(envParam, dqParam)
 
     // choose process
-    val procType = ProcessType(allParam.getDqConfig.getProcType)
+    val procType = ProcessType.withNameWithDefault(allParam.getDqConfig.getProcType)
     dqApp = procType match {
-      case BatchProcessType => BatchDQApp(allParam)
-      case StreamingProcessType => StreamingDQApp(allParam)
+      case ProcessType.BatchProcessType => BatchDQApp(allParam)
+      case ProcessType.StreamingProcessType => StreamingDQApp(allParam)
       case _ =>
         error(s"${procType} is unsupported process type!")
         sys.exit(-4)

--- a/measure/src/test/scala/org/apache/griffin/measure/job/DQAppTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/job/DQAppTest.scala
@@ -20,16 +20,15 @@ package org.apache.griffin.measure.job
 
 import scala.util.Failure
 import scala.util.Success
-
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import org.apache.griffin.measure.Application._
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.SparkSuiteBase
 import org.apache.griffin.measure.configuration.dqdefinition._
-import org.apache.griffin.measure.configuration.enums._
+import org.apache.griffin.measure.configuration.enums.ProcessType
+import org.apache.griffin.measure.configuration.enums.ProcessType._
 import org.apache.griffin.measure.launch.DQApp
 import org.apache.griffin.measure.launch.batch.BatchDQApp
 import org.apache.griffin.measure.launch.streaming.StreamingDQApp
@@ -58,8 +57,8 @@ class DQAppTest extends FlatSpec with SparkSuiteBase with BeforeAndAfterAll with
     // choose process
     val procType = ProcessType.withNameWithDefault(allParam.getDqConfig.getProcType)
     dqApp = procType match {
-      case ProcessType.BatchProcessType => BatchDQApp(allParam)
-      case ProcessType.StreamingProcessType => StreamingDQApp(allParam)
+      case BatchProcessType => BatchDQApp(allParam)
+      case StreamingProcessType => StreamingDQApp(allParam)
       case _ =>
         error(s"${procType} is unsupported process type!")
         sys.exit(-4)

--- a/measure/src/test/scala/org/apache/griffin/measure/sink/CustomSinkTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/sink/CustomSinkTest.scala
@@ -21,7 +21,7 @@ package org.apache.griffin.measure.sink
 import scala.collection.mutable
 
 import org.apache.griffin.measure.configuration.dqdefinition.{RuleOutputParam, SinkParam}
-import org.apache.griffin.measure.configuration.enums.FlattenType
+import org.apache.griffin.measure.configuration.enums.FlattenType.DefaultFlattenType
 import org.apache.griffin.measure.step.write.{MetricFlushStep, MetricWriteStep, RecordWriteStep}
 
 class CustomSinkTest extends SinkTestBase {
@@ -114,7 +114,7 @@ class CustomSinkTest extends SinkTestBase {
     val metricWriteStep = {
       val metricOpt = Some(metricsDefaultOutput)
       val mwName = metricOpt.flatMap(_.getNameOpt).getOrElse("default_metrics_name")
-      val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.DefaultFlattenType)
+      val flattenType = metricOpt.map(_.getFlatten).getOrElse(DefaultFlattenType)
       MetricWriteStep(mwName, resultTable, flattenType)
     }
 

--- a/measure/src/test/scala/org/apache/griffin/measure/sink/CustomSinkTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/sink/CustomSinkTest.scala
@@ -114,7 +114,7 @@ class CustomSinkTest extends SinkTestBase {
     val metricWriteStep = {
       val metricOpt = Some(metricsDefaultOutput)
       val mwName = metricOpt.flatMap(_.getNameOpt).getOrElse("default_metrics_name")
-      val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.default)
+      val flattenType = metricOpt.map(_.getFlatten).getOrElse(FlattenType.DefaultFlattenType)
       MetricWriteStep(mwName, resultTable, flattenType)
     }
 

--- a/measure/src/test/scala/org/apache/griffin/measure/sink/SinkTestBase.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/sink/SinkTestBase.scala
@@ -26,7 +26,7 @@ import org.scalatest.Matchers
 
 import org.apache.griffin.measure.Loggable
 import org.apache.griffin.measure.configuration.dqdefinition.SinkParam
-import org.apache.griffin.measure.configuration.enums.BatchProcessType
+import org.apache.griffin.measure.configuration.enums.ProcessType.BatchProcessType
 import org.apache.griffin.measure.context.{ContextId, DQContext}
 import org.apache.griffin.measure.SparkSuiteBase
 

--- a/measure/src/test/scala/org/apache/griffin/measure/step/TransformStepTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/step/TransformStepTest.scala
@@ -21,7 +21,7 @@ package org.apache.griffin.measure.step
 import org.scalatest._
 
 import org.apache.griffin.measure.Loggable
-import org.apache.griffin.measure.configuration.enums.BatchProcessType
+import org.apache.griffin.measure.configuration.enums.ProcessType.BatchProcessType
 import org.apache.griffin.measure.context.ContextId
 import org.apache.griffin.measure.context.DQContext
 import org.apache.griffin.measure.SparkSuiteBase

--- a/measure/src/test/scala/org/apache/griffin/measure/transformations/AccuracyTransformationsIntegrationTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/transformations/AccuracyTransformationsIntegrationTest.scala
@@ -20,9 +20,8 @@ package org.apache.griffin.measure.transformations
 
 import org.apache.spark.sql.DataFrame
 import org.scalatest._
-
 import org.apache.griffin.measure.configuration.dqdefinition._
-import org.apache.griffin.measure.configuration.enums.BatchProcessType
+import org.apache.griffin.measure.configuration.enums.{ProcessType}
 import org.apache.griffin.measure.context.{ContextId, DQContext}
 import org.apache.griffin.measure.datasource.DataSourceFactory
 import org.apache.griffin.measure.job.builder.DQJobBuilder
@@ -164,7 +163,7 @@ class AccuracyTransformationsIntegrationTest extends FlatSpec with Matchers with
       name,
       dataSources,
       Nil,
-      BatchProcessType
+      ProcessType.BatchProcessType
     )(spark)
   }
 

--- a/measure/src/test/scala/org/apache/griffin/measure/transformations/AccuracyTransformationsIntegrationTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/transformations/AccuracyTransformationsIntegrationTest.scala
@@ -21,7 +21,7 @@ package org.apache.griffin.measure.transformations
 import org.apache.spark.sql.DataFrame
 import org.scalatest._
 import org.apache.griffin.measure.configuration.dqdefinition._
-import org.apache.griffin.measure.configuration.enums.{ProcessType}
+import org.apache.griffin.measure.configuration.enums.ProcessType.BatchProcessType
 import org.apache.griffin.measure.context.{ContextId, DQContext}
 import org.apache.griffin.measure.datasource.DataSourceFactory
 import org.apache.griffin.measure.job.builder.DQJobBuilder
@@ -163,7 +163,7 @@ class AccuracyTransformationsIntegrationTest extends FlatSpec with Matchers with
       name,
       dataSources,
       Nil,
-      ProcessType.BatchProcessType
+      BatchProcessType
     )(spark)
   }
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**

All the predefined: `DQTypes, DSLTypes, FlattenType, OutputType, ProcessType, SinkType and WriteMode` are compared with config using a regex-based approach. This will make unnecessary overhead in terms of execution time and maintainability.

This PR uses a predefined enum based approach than regex-based to provide the same functionality.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Griffin test suite.