### PR TITLE
fix bug - when OutDfName is null

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/step/builder/SparkSqlDQStepBuilder.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/step/builder/SparkSqlDQStepBuilder.scala
@@ -26,13 +26,14 @@ case class SparkSqlDQStepBuilder() extends RuleParamStepBuilder {
 
   def buildSteps(context: DQContext, ruleParam: RuleParam): Seq[DQStep] = {
     val name = getStepName(ruleParam.getOutDfName())
+    val newRuleParam = ruleParam.replaceOutDfName(name)
     val transformStep = SparkSqlTransformStep(
       name,
       ruleParam.getRule,
       ruleParam.getDetails,
       None,
       ruleParam.getCache)
-    transformStep +: buildDirectWriteSteps(ruleParam)
+    transformStep +: buildDirectWriteSteps(newRuleParam)
   }
 
 }


### PR DESCRIPTION
fix bug - when OutDfName is null

if  ruleParam.getOutDfName() is null, the param "name" used by SparkSqlTransformStep will be different from used by DirectWriteStep, which will cause execute error : can not find table or view.....