### PR TITLE
Elastic Search index for each application instance

### DIFF
--- a/service/src/main/java/org/apache/griffin/core/metric/MetricStoreImpl.java
+++ b/service/src/main/java/org/apache/griffin/core/metric/MetricStoreImpl.java
@@ -56,7 +56,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class MetricStoreImpl implements MetricStore {
 
-    private static final String INDEX = "griffin";
+    @Value("${index}")
+    private String INDEX;
     private static final String TYPE = "accuracy";
 
     private RestClient client;

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -62,6 +62,7 @@ fs.defaultFS=
 elasticsearch.host=localhost
 elasticsearch.port=9200
 elasticsearch.scheme=http
+index=griffin
 # elasticsearch.user = user
 # elasticsearch.password = password
 # livy


### PR DESCRIPTION
This change is intended to create a separate elastic search index for each Griffin instance.
At the moment the value of elastic search index was hard coded in code resulting in creation of elastic search index with same name for every instance.
I have moved the hard coded value for elastic search index into properties value to get it customized for every individual application instance.