### PR TITLE
[griffin-service] use service tar.gz deploy and griffin.sh start

### DIFF
--- a/griffin-doc/deploy/deploy-guide.md
+++ b/griffin-doc/deploy/deploy-guide.md
@@ -533,21 +533,27 @@ Similar changes are required in `env_streaming.json`.
 }
 ```
 
-It's easy to build Griffin, just run maven command `mvn clean install`. Successfully building, you can get two jars `service-0.4.0.jar`,`measure-0.4.0.jar` from target folder in service and measure module.
+It's easy to build Griffin, just run maven command `mvn clean install`. Successfully building, you can get `service-${version}.tar.gz` and `measure-${version}.jar` from target folder in service and measure module.
 
 Upload measure's jar to hadoop folder.
 ```
 # change jar name
 mv measure-0.4.0.jar griffin-measure.jar
-mv service-0.4.0.jar griffin-service.jar
 # upload measure jar file
 hdfs dfs -put griffin-measure.jar /griffin/
 ```
 
-Startup service.jar，run Griffin management service.
+Startup service，run Griffin management service.
 ```
-cd $GRIFFIN_HOME
-nohup java -jar griffin-service.jar>service.out 2>&1 &
+cd $GRIFFIN_INSTALL_DIR
+tar -zxvf service-${version}.tar.gz
+cd service-${version}
+# start service
+./bin/griffin.sh start  
+# or use ./bin/start.sh
+# stop service
+./bin/griffin.sh stop
+# or use ./bin/stop.sh
 ```
 
 After a few seconds, we can visit our default UI of Apache Griffin (by default the port of spring boot is 8080).

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -372,15 +372,34 @@ under the License.
                 <executions>
                     <execution>
                         <goals>
-                            <goal>repackage</goal>
+                            <goal>build-info</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <fork>true</fork>
-                    <layout>JAR</layout>
-                    <mainClass>org.apache.griffin.core.GriffinWebApplication</mainClass>
+                    <executable>false</executable>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <skipAssembly>false</skipAssembly>
+                    <outputDirectory>../target</outputDirectory>
+                    <descriptors>
+                        <descriptor>src/main/resources/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/service/src/main/resources/assembly/assembly.xml
+++ b/service/src/main/resources/assembly/assembly.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd
+http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 ">
+    <id>${project.version}</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <!-- Adds dependencies to zip package under lib directory -->
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>./lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
+                <include>NOTICE*</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <outputDirectory>config/</outputDirectory>
+            <includes>
+                <include>env/*</include>
+                <include>*.xml</include>
+                <include>*.sql</include>
+                <include>*.json</include>
+                <include>*.properties</include>
+            </includes>
+            <excludes>
+                <exclude>*.txt</exclude>
+                <exclude>logback-test.xml</exclude>
+            </excludes>
+        </fileSet>
+
+        <fileSet>
+            <directory>src/main/resources/shell</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+            <filtered>true</filtered>
+            <fileMode>0755</fileMode>
+        </fileSet>
+
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./lib</outputDirectory>
+            <includes>
+                <include>*${version}.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/service/src/main/resources/shell/griffin.sh
+++ b/service/src/main/resources/shell/griffin.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+COMMAND="$1"
+
+# Get standard environment variables
+PRG_DIR=`dirname "$PRG"`
+GRIFFIN_HOME=`cd "$PRG_DIR/.." >/dev/null; pwd`
+export GRIFFIN_HOME
+
+mkdir -p $GRIFFIN_HOME/logs
+GRIFFIN_LOG_DIR=$GRIFFIN_HOME/logs
+
+mkdir -p $GRIFFIN_HOME/pid
+GRIFFIN_PID_DIR=$GRIFFIN_HOME/pid
+
+GRIFFIN_CONF_DIR="$GRIFFIN_HOME/config"
+GRIFFIN_LIB_DIR="$GRIFFIN_HOME/lib"
+export GRIFFIN_LIB_DIR
+
+LIB_JARS=`ls $GRIFFIN_LIB_DIR | grep -E '.jar$' | awk '{print "'$GRIFFIN_LIB_DIR'/"$0}' | tr "\n" ":"`
+
+PRO_NAME=${project.artifactId}
+PIDFILE="$GRIFFIN_PID_DIR/$(basename $PRO_NAME).pid"
+PID=0
+if [[ -f $PIDFILE ]]; then
+  PID=`cat $PIDFILE`
+fi
+
+JAVA_OPTS=""
+JAVA_MEM_OPTS=""
+
+MAIN_CLASS=${start-class}
+
+
+running() {
+  if [[ -z $1 || $1 == 0 ]]; then
+    echo 0
+    return
+  fi
+  if ps -p $1 > /dev/null; then
+    echo 1
+    return
+  fi
+  echo 0
+  return
+}
+
+set_env() {
+    if [ -r "$GRIFFIN_HOME/bin/setenv.sh" ]; then
+      source "$GRIFFIN_HOME/bin/setenv.sh"
+    else
+      JAVA_MEM_OPTS=" -server -Xms4g -Xmx4g -XX:SurvivorRatio=2 -XX:+UseParallelGC "
+    fi
+}
+
+start() {
+  if [[ $(running $PID) != 0 ]]; then
+    echo "$PRO_NAME is running"
+    return
+  fi
+  echo "### starting $PRO_NAME `date '+%Y-%m-%d %H:%M:%S'` ###" >> /dev/null 2>&1 &
+  set_env
+  echo "$JAVA_HOME/bin/java $JAVA_OPTS $JAVA_MEM_OPTS -classpath $GRIFFIN_CONF_DIR:$LIB_JARS $MAIN_CLASS"
+  START_CMD="$JAVA_HOME/bin/java $JAVA_OPTS $JAVA_MEM_OPTS -classpath $GRIFFIN_CONF_DIR:$LIB_JARS $MAIN_CLASS"
+  print_env
+  nohup $START_CMD >> $GRIFFIN_LOG_DIR/server.log 2>&1 &
+  if [[ $(running $!) == 0 ]]; then
+    echo "failed to start $PRO_NAME"
+    exit 1
+  fi
+  PID=$!
+  echo $! > $PIDFILE
+#  echo "new pid $!"
+}
+
+stop() {
+  if [[ $(running $PID) == 0 ]]; then
+    echo "no $PRO_NAME is running"
+    return
+  fi
+  echo "stopping $PID of $PRO_NAME ..."
+  kill $PID
+}
+
+restart() {
+  stop
+  start
+}
+
+print_env() {
+  echo "JRE_HOME:               $JAVA_HOME"
+  echo "JAVA_OPTS:              $JAVA_OPTS"
+  echo "JAVA_MEM_OPTS:          $JAVA_MEM_OPTS"
+  echo "START_CMD:              $START_CMD"
+}
+
+print_usage() {
+  echo "Usage: griffin.sh (start|stop)"
+}
+
+case $COMMAND in
+
+(start)
+  start
+  ;;
+
+(stop)
+  stop
+  ;;
+
+(*)
+  print_usage
+  exit 1
+  ;;
+esac

--- a/service/src/main/resources/shell/setenv.sh
+++ b/service/src/main/resources/shell/setenv.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+PRG_DIR=`dirname "$PRG"`
+GRIFFIN_HOME=`cd "$PRG_DIR/.." >/dev/null; pwd`
+
+mkdir -p $GRIFFIN_HOME/logs
+GRIFFIN_LOG_DIR=$GRIFFIN_HOME/logs
+
+#server memory
+export JAVA_MEM_OPTS="$JAVA_MEM_OPTS -server -Xms1G -Xmx1G -Xmn512M -XX:PermSize=128M -XX:MaxPermSize=256M -Xss512k -XX:SurvivorRatio=8"
+
+#gc
+export JAVA_MEM_OPTS="$JAVA_MEM_OPTS -XX:MaxTenuringThreshold=4 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSCompactAtFullCollection -XX:CMSFullGCsBeforeCompaction=2 -XX:+ExplicitGCInvokesConcurrent  -XX:+CMSScavengeBeforeRemark"
+
+#gc log
+export JAVA_MEM_OPTS="$JAVA_MEM_OPTS -Xloggc:$GRIFFIN_LOG_DIR/gc.log.`date +%Y-%m-%d_%H_%M_%S` \
+ -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:PrintFLSStatistics=1"
+
+#oom
+export JAVA_MEM_OPTS="$JAVA_MEM_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$GRIFFIN_LOG_DIR/heapdump.hprof"

--- a/service/src/main/resources/shell/start.sh
+++ b/service/src/main/resources/shell/start.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+GRIFFIN_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
+EXECUTABLE=griffin.sh
+exec "$PRGDIR"/"$EXECUTABLE" start "$@"

--- a/service/src/main/resources/shell/stop.sh
+++ b/service/src/main/resources/shell/stop.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+GRIFFIN_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
+EXECUTABLE=griffin.sh
+exec "$PRGDIR"/"$EXECUTABLE" stop "$@"


### PR DESCRIPTION
   If we use` java -jar` start service ,then It is inconvenient to modify the configuration file. Modifying the configuration file requires recompiling the jar. And it is inconvenient to stop the service.
   This PR provides `tar.gz` installation method and shell startup method，and it has been deployed and run in our production environment.

1. ls -al service-0.6.0-SNAPSHOT
     bin
     config
     lib

2. cd service-0.6.0-SNAPSHOT/

3. ./bin/griffin.sh start

4. jps
   17860 GriffinWebApplication

5. ./bin/griffin.sh stop
    stopping 17860 of service ...
 
  If start service, we can access http://${ip}:8080
![image](https://user-images.githubusercontent.com/20353043/92120728-ffc00480-ee2b-11ea-9e9b-8a02d208bf4b.png)



