### PR TITLE
[GRIFFIN-362] Add postgresql and oracle driver into dependencies.

### DIFF
--- a/measure/pom.xml
+++ b/measure/pom.xml
@@ -53,6 +53,8 @@ under the License.
         <scalaj.version>2.3.0</scalaj.version>
         <mongo.version>2.1.0</mongo.version>
         <curator.version>2.10.0</curator.version>
+        <postgresql.version>9.4.1212.jre7</postgresql.version>
+        <ojdbc8.version>21.4.0.0.1</ojdbc8.version>
 
         <!-- Testing -->
         <scoverage.plugin.version>1.4.0</scoverage.plugin.version>
@@ -149,6 +151,20 @@ under the License.
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.java.version}</version>
+        </dependency>
+
+        <!-- PostgreSQL -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+        </dependency>
+
+        <!-- Oracle -->
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${ojdbc8.version}</version>
         </dependency>
 
         <!-- MariaDB -->

--- a/measure/pom.xml
+++ b/measure/pom.xml
@@ -53,7 +53,7 @@ under the License.
         <scalaj.version>2.3.0</scalaj.version>
         <mongo.version>2.1.0</mongo.version>
         <curator.version>2.10.0</curator.version>
-        <postgresql.version>9.4.1212.jre7</postgresql.version>
+        <postgresql.version>42.3.1</postgresql.version>
         <ojdbc8.version>21.4.0.0.1</ojdbc8.version>
 
         <!-- Testing -->

--- a/measure/src/test/scala/org/apache/griffin/measure/datasource/connector/batch/JDBCBasedDataConnectorTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/datasource/connector/batch/JDBCBasedDataConnectorTest.scala
@@ -132,7 +132,7 @@ class JDBCBasedDataConnectorTest extends SparkSuiteBase with Matchers {
     } should have message "requirement failed: JDBC connection: password is mandatory"
   }
 
-  "JDBC data connector" should "have driver provided in config in classpath" in {
+  "JDBC data connector" should "have valid driver provided in config in classpath" in {
     the[AssertionError] thrownBy {
       val configs = Map(
         "database" -> "griffin",
@@ -140,7 +140,7 @@ class JDBCBasedDataConnectorTest extends SparkSuiteBase with Matchers {
         "tablename" -> "employee",
         "user" -> "user",
         "password" -> "password",
-        "driver" -> "org.postgresql.Driver")
+        "driver" -> "org.postgresql.InvalidDriver")
       JDBCBasedDataConnector(spark, dcParam.copy(config = configs), timestampStorage)
     }
   }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -44,7 +44,7 @@ under the License.
         <derby.version>10.14.1.0</derby.version>
         <eclipselink.version>2.6.0</eclipselink.version>
         <mysql.java.version>5.1.47</mysql.java.version>
-        <postgresql.version>9.4.1212.jre7</postgresql.version>
+        <postgresql.version>42.3.1</postgresql.version>
         <livy.core.version>0.3.0</livy.core.version>
         <elasticsearch-rest-client.version>6.2.4</elasticsearch-rest-client.version>
         <jackson-databind.version>2.9.9.3</jackson-databind.version>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
1. Add Oracle and postgresql JDBC driver into dependencies in measure module due user report 
https://issues.apache.org/jira/browse/GRIFFIN-362
2. Update postgresql jdbc driver version to the latest in service module. 

**Does this PR introduce any user-facing change?**
No.

How was this patch tested?
Unit Tests
