### PR TITLE
[GRIFFIN-352] Resolve conflicts between Guava versions

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/utils/ThreadUtils.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/utils/ThreadUtils.scala
@@ -18,17 +18,93 @@
 package org.apache.griffin.measure.utils
 
 import java.util.concurrent._
+import java.util.concurrent.locks.ReentrantLock
 
 import scala.concurrent.{Awaitable, ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
-import com.google.common.util.concurrent.{MoreExecutors, ThreadFactoryBuilder}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 private[griffin] object ThreadUtils {
 
   private val sameThreadExecutionContext =
-    ExecutionContext.fromExecutorService(MoreExecutors.sameThreadExecutor())
+    ExecutionContext.fromExecutorService(sameThreadExecutorService())
+
+  // Inspired by Guava MoreExecutors.sameThreadExecutor; inlined and converted
+  // to Scala here to avoid Guava version issues
+  def sameThreadExecutorService(): ExecutorService = new AbstractExecutorService {
+    private val lock = new ReentrantLock()
+    private val termination = lock.newCondition()
+    private var runningTasks = 0
+    private var serviceIsShutdown = false
+
+    override def shutdown(): Unit = {
+      lock.lock()
+      try {
+        serviceIsShutdown = true
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def shutdownNow(): java.util.List[Runnable] = {
+      shutdown()
+      java.util.Collections.emptyList()
+    }
+
+    override def isShutdown: Boolean = {
+      lock.lock()
+      try {
+        serviceIsShutdown
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def isTerminated: Boolean = synchronized {
+      lock.lock()
+      try {
+        serviceIsShutdown && runningTasks == 0
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+      var nanos = unit.toNanos(timeout)
+      lock.lock()
+      try {
+        while (nanos > 0 && !isTerminated()) {
+          nanos = termination.awaitNanos(nanos)
+        }
+        isTerminated()
+      } finally {
+        lock.unlock()
+      }
+    }
+
+    override def execute(command: Runnable): Unit = {
+      lock.lock()
+      try {
+        if (isShutdown()) throw new RejectedExecutionException("Executor already shutdown")
+        runningTasks += 1
+      } finally {
+        lock.unlock()
+      }
+      try {
+        command.run()
+      } finally {
+        lock.lock()
+        try {
+          runningTasks -= 1
+          if (isTerminated()) termination.signalAll()
+        } finally {
+          lock.unlock()
+        }
+      }
+    }
+  }
 
   /**
    * An `ExecutionContextExecutor` that runs each task in the thread that invokes `execute/submit`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Resolve conflicts between Guava versions. 

### Why are the changes needed?

`NoSuchMethodError` will be thrown now.

```
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;
        at org.apache.griffin.measure.utils.ThreadUtils$.<init>(ThreadUtils.scala:35)
        at org.apache.griffin.measure.utils.ThreadUtils$.<clinit>(ThreadUtils.scala)
        at org.apache.griffin.measure.step.transform.TransformStep$.<init>(TransformStep.scala:118)
        at org.apache.griffin.measure.step.transform.TransformStep$.<clinit>(TransformStep.scala)
        at org.apache.griffin.measure.step.transform.TransformStep$$anonfun$3.apply(TransformStep.scala:61)
        at org.apache.griffin.measure.step.transform.TransformStep$$anonfun$3.apply(TransformStep.scala:51)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.mutable.HashSet.foreach(HashSet.scala:78)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
        at scala.collection.mutable.AbstractSet.scala$collection$SetLike$$super$map(Set.scala:46)
        at scala.collection.SetLike$class.map(SetLike.scala:92)
        at scala.collection.mutable.AbstractSet.map(Set.scala:46)
        at org.apache.griffin.measure.step.transform.TransformStep$class.execute(TransformStep.scala:51)
        at org.apache.griffin.measure.step.transform.SparkSqlTransformStep.execute(SparkSqlTransformStep.scala:28)
        at org.apache.griffin.measure.job.DQJob$$anonfun$execute$2.apply(DQJob.scala:29)
        at org.apache.griffin.measure.job.DQJob$$anonfun$execute$2.apply(DQJob.scala:29)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.immutable.List.foreach(List.scala:392)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
        at scala.collection.immutable.List.map(List.scala:296)
        at org.apache.griffin.measure.job.DQJob.execute(DQJob.scala:29)
        at org.apache.griffin.measure.launch.batch.BatchDQApp$$anonfun$1.apply(BatchDQApp.scala:85)
        at org.apache.griffin.measure.launch.batch.BatchDQApp$$anonfun$1.apply(BatchDQApp.scala:64)
        at org.apache.griffin.measure.utils.CommonUtils$.timeThis(CommonUtils.scala:36)
        at org.apache.griffin.measure.launch.batch.BatchDQApp.run(BatchDQApp.scala:64)
        at org.apache.griffin.measure.Application$.main(Application.scala:92)
        at org.apache.griffin.measure.Application.main(Application.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
        at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:847)
        at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:161)
        at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:184)
        at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:86)
        at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:922)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:931)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)

```

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Exists UTs.
