### PR TITLE
Resolving type compatibility conflicts in ElasticSearchGriffinDataConnector

### DIFF
--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/ElasticSearchGriffinDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/ElasticSearchGriffinDataConnector.scala
@@ -21,7 +21,7 @@ import java.io.{BufferedReader, ByteArrayInputStream, InputStreamReader}
 import java.net.URI
 import java.util.{Iterator => JavaIterator, Map => JavaMap}
 
-import scala.collection.JavaConverters
+import scala.collection.JavaConversions
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -83,8 +83,10 @@ case class ElasticSearchGriffinDataConnector(
         val answer = httpPost(path, sql)
         if (answer._1) {
           import sparkSession.implicits._
-          val rdd: RDD[String] = sparkSession.sparkContext.parallelize(Seq(JavaConverters.asScalaIteratorConverter(
-            answer._2.lines.toList.iterator()).asScala.toString()))
+          val rdd: RDD[String] = sparkSession.sparkContext.parallelize(
+            Seq(
+              JavaConversions
+                .asJavaIterable(answer._2.lines.toList)))
           val reader: DataFrameReader = sparkSession.read
           reader.option("header", value = true).option("inferSchema", value = true)
           val df: DataFrame = reader.csv(rdd.toDS())

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/ElasticSearchGriffinDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/ElasticSearchGriffinDataConnector.scala
@@ -86,7 +86,8 @@ case class ElasticSearchGriffinDataConnector(
           val rdd: RDD[String] = sparkSession.sparkContext.parallelize(
             Seq(
               JavaConversions
-                .asJavaIterable(answer._2.lines.toList)))
+                .asJavaIterable(answer._2.lines.toList)
+                .toString))
           val reader: DataFrameReader = sparkSession.read
           reader.option("header", value = true).option("inferSchema", value = true)
           val df: DataFrame = reader.csv(rdd.toDS())

--- a/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/ElasticSearchGriffinDataConnector.scala
+++ b/measure/src/main/scala/org/apache/griffin/measure/datasource/connector/batch/ElasticSearchGriffinDataConnector.scala
@@ -21,6 +21,7 @@ import java.io.{BufferedReader, ByteArrayInputStream, InputStreamReader}
 import java.net.URI
 import java.util.{Iterator => JavaIterator, Map => JavaMap}
 
+import scala.collection.JavaConverters
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -82,7 +83,8 @@ case class ElasticSearchGriffinDataConnector(
         val answer = httpPost(path, sql)
         if (answer._1) {
           import sparkSession.implicits._
-          val rdd: RDD[String] = sparkSession.sparkContext.parallelize(answer._2.lines.toList)
+          val rdd: RDD[String] = sparkSession.sparkContext.parallelize(Seq(JavaConverters.asScalaIteratorConverter(
+            answer._2.lines.toList.iterator()).asScala.toString()))
           val reader: DataFrameReader = sparkSession.read
           reader.option("header", value = true).option("inferSchema", value = true)
           val df: DataFrame = reader.csv(rdd.toDS())


### PR DESCRIPTION
Reason:

env: mac Big Sur m1 11.2.3

<img width="1020" alt="type1" src="https://user-images.githubusercontent.com/20021404/178086905-579df466-7a3f-484b-9338-2495f373d85d.png">


During the dataBySql conversion process, because the load parameter of httpUrl does not conform to the construction specification of parallelize when it is passed in before the RDD construction, it is fixed.


test result:
![4211657331715_ pic](https://user-images.githubusercontent.com/20021404/178087355-7b65f9f5-3544-4b54-ae09-322b67bd9e2c.jpg)
![4221657331715_ pic](https://user-images.githubusercontent.com/20021404/178087384-cde4ad67-3393-4984-afb8-0e167ff82178.jpg)
