### PR TITLE
JDBC Connector SQL mode

### DIFF
--- a/griffin-doc/measure/measure-configuration-guide.md
+++ b/griffin-doc/measure/measure-configuration-guide.md
@@ -547,6 +547,7 @@ List of supported data connectors:
 | Name       | Type     | Description                            | Default Values |
 |:-----------|:---------|:---------------------------------------|:-------------- |
 | database   | `String` | database name                          | default |
+| sql        | `String` | query sql                              | `Empty` |
 | tablename  | `String` | table name to be read                  | `Empty` |
 | url        | `String` | the connection string URL to database  | `Empty` |
 | user       | `String` | user for connection to database        | `Empty` |
@@ -554,6 +555,7 @@ List of supported data connectors:
 | driver     | `String` | driver class for JDBC connection to database | com.mysql.jdbc.Driver |
 | where      | `String` | condition for reading data from table  | `Empty` |
 
+- The config `sql` and `tablename` cannot be all empty. If sql is not empty, connector will extract the result of sql.
 - Example:
    ```
   "connector": {

--- a/griffin-doc/measure/measure-configuration-guide.md
+++ b/griffin-doc/measure/measure-configuration-guide.md
@@ -547,16 +547,16 @@ List of supported data connectors:
 | Name       | Type     | Description                            | Default Values |
 |:-----------|:---------|:---------------------------------------|:-------------- |
 | database   | `String` | database name                          | default |
-| sql        | `String` | query sql                              | `Empty` |
 | tablename  | `String` | table name to be read                  | `Empty` |
 | url        | `String` | the connection string URL to database  | `Empty` |
 | user       | `String` | user for connection to database        | `Empty` |
 | password   | `String` | password for connection to database    | `null`  |
 | driver     | `String` | driver class for JDBC connection to database | com.mysql.jdbc.Driver |
 | where      | `String` | condition for reading data from table  | `Empty` |
+| sql        | `String` | query sql                              | `Empty` |
 
-- The config `sql` and `tablename` cannot be all empty. If sql is not empty, connector will extract the result of sql.
-- Example:
+
+- Example (without `sql` provided):
    ```
   "connector": {
       "type": "jdbc",
@@ -568,6 +568,20 @@ List of supported data connectors:
         "password": "test_p",
         "driver": "com.mysql.jdbc.Driver",
         "where": ""
+      }
+    } 
+
+- If the config `sql` was provided, `database`, `tablename` and `where` can all be ignored, connector will extract the result of sql.
+- Example (with `sql` provided):
+   ```
+  "connector": {
+      "type": "jdbc",
+      "config": {
+        "sql": "select col_a, col_b from griffin.griffin where id > 100 limit 100",
+        "url": "jdbc:mysql://localhost:3306/default",
+        "user": "test_u",
+        "password": "test_p",
+        "driver": "com.mysql.jdbc.Driver",
       }
     } 
   

--- a/measure/src/test/scala/org/apache/griffin/measure/datasource/connector/batch/JDBCBasedDataConnectorTest.scala
+++ b/measure/src/test/scala/org/apache/griffin/measure/datasource/connector/batch/JDBCBasedDataConnectorTest.scala
@@ -105,7 +105,19 @@ class JDBCBasedDataConnectorTest extends SparkSuiteBase with Matchers {
         "password" -> "password",
         "driver" -> "org.h2.Driver")
       JDBCBasedDataConnector(spark, dcParam.copy(config = configs), timestampStorage)
-    } should have message "requirement failed: JDBC connection: table is mandatory"
+    } should have message "requirement failed: JDBC connection: sql or table is mandatory"
+  }
+
+  "JDBC data connector" should "have user name field in config" in {
+    the[java.lang.IllegalArgumentException] thrownBy {
+      val configs = Map(
+        "database" -> "griffin",
+        "url" -> url,
+        "sql" -> "select col_a, col_b, col_c from griffin.griffin limit 10000",
+        "password" -> "password",
+        "driver" -> "org.h2.Driver")
+      JDBCBasedDataConnector(spark, dcParam.copy(config = configs), timestampStorage)
+    } should have message "requirement failed: JDBC connection: user name is mandatory"
   }
 
   "JDBC data connector" should "have user name field in config" in {


### PR DESCRIPTION
# What changes were proposed in this pull request?
JDBC connector could configuring sql which would get sql results as datasource.
It is more flexible to use. And in some special cases (such as only a small number of columns need to be extracted), it can reduce the IO of loading data from db.

# Does this PR introduce any user-facing change?
No. The original configuration mode is not affected.

# How was this patch tested?
Unit Tests. And it has been used in our production environment for several months.